### PR TITLE
Reuse subscriptions fix

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -379,11 +379,14 @@ public class Client {
     public Subscription subscribe(String channel, SubscriptionEventListener listener) throws DuplicateSubscriptionException {
         Subscription sub;
         synchronized (this.subs) {
-            if (this.subs.get(channel) != null) {
-                throw new DuplicateSubscriptionException();
+            Subscription cached = getSub(channel);
+            if (cached != null) {
+                sub = cached;
+                sub.setListener(listener);
+            } else {
+                sub = new Subscription(Client.this, channel, listener);
+                this.subs.put(channel, sub);
             }
-            sub = new Subscription(Client.this, channel, listener);
-            this.subs.put(channel, sub);
         }
         this.executor.submit(() -> {
             if (Client.this.state != ConnectionState.CONNECTED) {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -353,6 +353,7 @@ public class Client {
         f.thenAccept(reply -> {
             this.handleUnsubscribeReply(channel, reply);
             this.futures.remove(cmd.getId());
+	    this.subs.remove(sub.getChannel());
         }).orTimeout(this.opts.getTimeout(), TimeUnit.MILLISECONDS).exceptionally(e -> {
             this.futures.remove(cmd.getId());
             e.printStackTrace();

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -372,7 +372,7 @@ public class Client {
         return stream.toByteArray();
     }
 
-    private Subscription getSub(String channel) {
+    public Subscription getSub(String channel) {
         return this.subs.get(channel);
     }
 

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
@@ -31,7 +31,7 @@ public class Subscription {
         return channel;
     }
 
-    SubscriptionEventListener getListener() {
+    public SubscriptionEventListener getListener() {
         return listener;
     }
 

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
@@ -12,6 +12,7 @@ public class Subscription {
 
     private Client client;
     private String channel;
+
     private SubscriptionEventListener listener;
     private SubscriptionState state = SubscriptionState.UNSUBSCRIBED;
     private Map<String, CompletableFuture<ReplyError>> futures = new ConcurrentHashMap<>();
@@ -31,8 +32,12 @@ public class Subscription {
         return channel;
     }
 
-    public SubscriptionEventListener getListener() {
+    SubscriptionEventListener getListener() {
         return listener;
+    }
+
+    void setListener(SubscriptionEventListener listener) {
+        this.listener = listener;
     }
 
     Subscription(final Client client, final String channel, final SubscriptionEventListener listener) {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/UnsubscribeOptions.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/UnsubscribeOptions.java
@@ -1,0 +1,34 @@
+package io.github.centrifugal.centrifuge;
+
+public class UnsubscribeOptions {
+
+    private final boolean permanent;
+
+    private UnsubscribeOptions(boolean permanent) {
+        this.permanent = permanent;
+    }
+
+    boolean isPermanent() {
+        return permanent;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private boolean permanent;
+
+        public Builder setPermanent(boolean permanent) {
+            this.permanent = permanent;
+            return this;
+        }
+
+        public UnsubscribeOptions build() {
+            return new UnsubscribeOptions(permanent);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Allows to subscribe to a channel several times without changing `Client`'s interface. If `Subscription` object exists, sets new `SubscriptionEventListener` to it