### PR TITLE
Migrate to Gradle 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,25 @@ mv io/github/centrifugal/centrifuge/internal/protocol/Protocol.java centrifuge/s
 rm -r io/
 ```
 
-### Release
+## For maintainer
+
+### release
+
+Create configuration file `gradle.properties` in `GRADLE_USER_HOME`:
+
+```
+signing.keyId=<LAST_8_SYMBOLS_OF_KEY_ID>
+signing.password=<PASSWORD>
+signing.secretKeyRingFile=/Path/to/.gnupg/secring.gpg
+
+ossrhUsername=<USERNAME>
+ossrhPassword=<PASSWORD>
+```
 
 Bump version in `centrifuge/build.gradle`. Write changelog. Create new library tag. Then run:
 
 ```
-./gradlew uploadArchives
+./gradlew publish
 ```
 
 Then follow instructions:

--- a/centrifuge/build.gradle
+++ b/centrifuge/build.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'maven'
+apply plugin: 'maven-publish'
 apply plugin: 'signing'
 apply plugin: 'java-library'
 
@@ -16,10 +16,6 @@ artifacts {
     archives javadocJar, sourcesJar
 }
 
-signing {
-    sign configurations.archives
-}
-
 group = "io.github.centrifugal"
 archivesBaseName = "centrifuge-java"
 version = "0.0.6"
@@ -33,47 +29,72 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 }
 
-uploadArchives {
-    repositories {
-        mavenDeployer {
-            beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+java {
+    withJavadocJar()
+    withSourcesJar()
+}
 
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(userName: findProperty('ossrhUsername'), password: findProperty('ossrhPassword'))
-            }
-
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(userName: findProperty('ossrhUsername'), password: findProperty('ossrhPassword'))
-            }
-
-            pom.project {
-                name 'Centrifuge Java'
-                packaging 'jar'
-                // optionally artifactId can be defined here
-                description 'Android and General Java client for Centrifugo server and Centrifuge library'
-                url 'https://github.com/centrifugal/centrifuge-java'
-
-                scm {
-                    connection 'scm:git:git://github.com/centrifugal/centrifuge-java.git'
-                    developerConnection 'scm:git:ssh://github.com:centrifugal/centrifuge-java.git'
-                    url 'http://github.com/centrifugal/centrifuge-java'
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'centrifuge-java'
+            from components.java
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
                 }
+                usage('java-runtime') {
+                    fromResolutionResult()
+                }
+            }
+            pom {
+                name = 'Centrifuge Java'
+                description = 'Android and General Java client for Centrifugo server and Centrifuge library'
+                url = 'https://github.com/centrifugal/centrifuge-java'
 
                 licenses {
                     license {
-                        name 'MIT License'
-                        url 'http://www.opensource.org/licenses/mit-license.php'
+                        name = 'MIT License'
+                        url = 'http://www.opensource.org/licenses/mit-license.php'
                     }
                 }
 
                 developers {
                     developer {
-                        id 'FZambia'
-                        name 'Alexander Emelin'
-                        email 'frvzmb@gmail.com'
+                        id = 'FZambia'
+                        name = 'Alexander Emelin'
+                        email = 'frvzmb@gmail.com'
                     }
+                }
+
+                scm {
+                    connection = 'scm:git:git://github.com/centrifugal/centrifuge-java.git'
+                    developerConnection = 'scm:git:ssh://github.com:centrifugal/centrifuge-java.git'
+                    url = 'http://github.com/centrifugal/centrifuge-java'
                 }
             }
         }
+    }
+    repositories {
+        maven {
+            name = "OSSRH"
+            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+            credentials {
+                username = findProperty('ossrhUsername')
+                password = findProperty('ossrhPassword')
+            }
+            url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
+        }
+    }
+}
+
+signing {
+    sign publishing.publications.mavenJava
+}
+
+javadoc {
+    if(JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip


### PR DESCRIPTION
Some tweaks to work with Gradle 7. We are using `maven-publish` plugin instead of `maven` now. 