### PR TITLE
fix PublishEvent: Add ClientInfo

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -682,6 +682,8 @@ public class Client {
                         ServerPublishEvent publishEvent = new ServerPublishEvent();
                         publishEvent.setChannel(channel);
                         publishEvent.setData(publication.getData().toByteArray());
+                        ClientInfo info = ClientInfo.fromProtocolClientInfo(publication.getInfo());
+                        publishEvent.setInfo(info);
                         publishEvent.setOffset(publication.getOffset());
                         this.listener.onPublish(this, publishEvent);
                         serverSub.setLastOffset(publication.getOffset());
@@ -829,10 +831,12 @@ public class Client {
             String channel = push.getChannel();
             if (push.getType() == Protocol.Push.PushType.PUBLICATION) {
                 Protocol.Publication pub = Protocol.Publication.parseFrom(push.getData());
+                ClientInfo info = ClientInfo.fromProtocolClientInfo(pub.getInfo());
                 Subscription sub = this.getSub(channel);
                 if (sub != null) {
                     PublishEvent event = new PublishEvent();
                     event.setData(pub.getData().toByteArray());
+                    event.setInfo(info);
                     event.setOffset(pub.getOffset());
                     sub.getListener().onPublish(sub, event);
                     sub.setLastOffset(pub.getOffset());
@@ -842,6 +846,7 @@ public class Client {
                         ServerPublishEvent event = new ServerPublishEvent();
                         event.setChannel(channel);
                         event.setData(pub.getData().toByteArray());
+                        event.setInfo(info);
                         event.setOffset(pub.getOffset());
                         this.listener.onPublish(this, event);
                         serverSub.setLastOffset(pub.getOffset());
@@ -857,11 +862,7 @@ public class Client {
                 serverSub.setLastOffset(sub.getOffset());
             } else if (push.getType() == Protocol.Push.PushType.JOIN) {
                 Protocol.Join join = Protocol.Join.parseFrom(push.getData());
-                ClientInfo info = new ClientInfo();
-                info.setClient(join.getInfo().getClient());
-                info.setUser(join.getInfo().getUser());
-                info.setConnInfo(join.getInfo().getConnInfo().toByteArray());
-                info.setChanInfo(join.getInfo().getChanInfo().toByteArray());
+                ClientInfo info = ClientInfo.fromProtocolClientInfo(join.getInfo());
                 Subscription sub = this.getSub(channel);
                 if (sub != null) {
                     JoinEvent event = new JoinEvent();
@@ -876,11 +877,7 @@ public class Client {
             } else if (push.getType() == Protocol.Push.PushType.LEAVE) {
                 Protocol.Leave leave = Protocol.Leave.parseFrom(push.getData());
                 LeaveEvent event = new LeaveEvent();
-                ClientInfo info = new ClientInfo();
-                info.setClient(leave.getInfo().getClient());
-                info.setUser(leave.getInfo().getUser());
-                info.setConnInfo(leave.getInfo().getConnInfo().toByteArray());
-                info.setChanInfo(leave.getInfo().getChanInfo().toByteArray());
+                ClientInfo info = ClientInfo.fromProtocolClientInfo(leave.getInfo());
 
                 Subscription sub = this.getSub(channel);
                 if (sub != null) {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ClientInfo.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ClientInfo.java
@@ -42,12 +42,22 @@ public class ClientInfo {
     private byte[] connInfo;
     private byte[] chanInfo;
 
+    /**
+     * Parse ClientInfo from Protocol.ClientInfo. Can return null if the Protocol.ClientInfo is null
+     *
+     * @param protoClientInfo which is the ClientInfo from the protocol object
+     * @return ClientInfo that can be null if the Protocol.ClientInfo passed is null
+     */
     static ClientInfo fromProtocolClientInfo(Protocol.ClientInfo protoClientInfo) {
-        ClientInfo clientInfo = new ClientInfo();
-        clientInfo.setUser(protoClientInfo.getUser());
-        clientInfo.setClient(protoClientInfo.getClient());
-        clientInfo.setConnInfo(protoClientInfo.getConnInfo().toByteArray());
-        clientInfo.setChanInfo(protoClientInfo.getChanInfo().toByteArray());
-        return clientInfo;
+        if (protoClientInfo != null) {
+            ClientInfo clientInfo = new ClientInfo();
+            clientInfo.setUser(protoClientInfo.getUser());
+            clientInfo.setClient(protoClientInfo.getClient());
+            clientInfo.setConnInfo(protoClientInfo.getConnInfo().toByteArray());
+            clientInfo.setChanInfo(protoClientInfo.getChanInfo().toByteArray());
+            return clientInfo;
+        } else {
+            return null;
+        }
     };
 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/PublishEvent.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/PublishEvent.java
@@ -11,6 +11,17 @@ public class PublishEvent {
 
     private byte[] data;
 
+    public ClientInfo getInfo() {
+        return info;
+    }
+
+    void setInfo(ClientInfo info) {
+        this.info = info;
+    }
+
+    private ClientInfo info;
+
+
     public long getOffset() {
         return offset;
     }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ServerPublishEvent.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ServerPublishEvent.java
@@ -11,6 +11,16 @@ public class ServerPublishEvent {
 
     private byte[] data;
 
+    public ClientInfo getInfo() {
+        return info;
+    }
+
+    void setInfo(ClientInfo info) {
+        this.info = info;
+    }
+
+    private ClientInfo info;
+
     public long getOffset() {
         return offset;
     }


### PR DESCRIPTION
In `centrifuge-go` a publish event (Publication struct) has 3 values - `Offset`, `Data` and `Info` ([view implementation](https://github.com/centrifugal/centrifuge-go/blob/595eded263578dd44cb6f2b6a8d3a08ac34b8f4a/protocol.go#L18)). But the java client only has 2 - offset and data.
This commit adds `info` to the `PublishEvent` class and sets it in the Client class.