### PR TITLE
Update Javalite Dependency and change implementation to api

### DIFF
--- a/centrifuge/build.gradle
+++ b/centrifuge/build.gradle
@@ -22,7 +22,7 @@ version = "0.1.0"
 
 dependencies {
     implementation 'com.squareup.okhttp3:okhttp:3.14.9'
-    implementation 'com.google.protobuf:protobuf-javalite:3.11.4'
+    api 'com.google.protobuf:protobuf-javalite:3.19.2'
     implementation 'net.sourceforge.streamsupport:streamsupport-cfuture:1.7.0'
     implementation 'com.google.code.gson:gson:2.8.6'
 


### PR DESCRIPTION
Update  ``` com.google.protobuf:protobuf-javalite: ```  ```3.19.2```  to ``` 3.19.2 ```
Change  ``` implementation ``` to ``` api ```, because ```api``` is the correct way to add a dependency in lib and solved many problems and conflicts in other dependencies.