### PR TITLE
Fix reconnect after onFailure

### DIFF
--- a/example/src/main/java/io/github/centrifugal/centrifuge/example/Main.java
+++ b/example/src/main/java/io/github/centrifugal/centrifuge/example/Main.java
@@ -45,7 +45,7 @@ public class Main {
         EventListener listener = new EventListener() {
             @Override
             public void onConnected(Client client, ConnectedEvent event) {
-                System.out.println("connected");
+                System.out.printf("connected with client id %s%n", event.getClient());
             }
             @Override
             public void onConnecting(Client client, ConnectingEvent event) {
@@ -66,7 +66,7 @@ public class Main {
             }
             @Override
             public void onSubscribed(Client client, ServerSubscribedEvent event) {
-                System.out.println("server side subscribe: " + event.getChannel() + ", recovered " + event.getRecovered());
+                System.out.println("server side subscribed: " + event.getChannel() + ", recovered " + event.getRecovered());
             }
             @Override
             public void onSubscribing(Client client, ServerSubscribingEvent event) {
@@ -74,7 +74,7 @@ public class Main {
             }
             @Override
             public void onUnsubscribed(Client client, ServerUnsubscribedEvent event) {
-                System.out.println("server side unsubscribe: " + event.getChannel());
+                System.out.println("server side unsubscribed: " + event.getChannel());
             }
             @Override
             public void onPublication(Client client, ServerPublicationEvent event) {
@@ -206,8 +206,8 @@ public class Main {
         sub.unsubscribe();
 
         // Say Client that we finished with Subscription. It will be removed from
-        // internal Subscription map so you can create new Subscription to channel
-        // later calling newSubscription method again.
+        // the internal Subscription map so you can create new Subscription to the
+        // channel later calling newSubscription method again.
         client.removeSubscription(sub);
 
         try {
@@ -219,15 +219,11 @@ public class Main {
         client.disconnect();
 
         try {
-            System.out.println(client.getState() == ClientState.DISCONNECTED);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-
-        try {
             boolean ok = client.close(5000);
             if (!ok) {
                 System.out.println("client was not gracefully closed");
+            } else {
+                System.out.println("client gracefully closed");
             }
         } catch (InterruptedException e) {
             e.printStackTrace();


### PR DESCRIPTION
In some scenarios onFailure can be called while connection is in CONNECTED state. For example, by setting reliability to 0% in Charles Proxy during live connection I was able to get EOF exception in onFailure, and `onClosed` callback never called in this case. According to okhttp docs for https://square.github.io/okhttp/4.x/okhttp/okhttp3/-web-socket-listener/on-failure/

> Invoked when a web socket has been closed due to an error reading from or writing to the network. Both outgoing and incoming messages may have been lost. No further calls to this listener will be made.

So we need to schedule reconnect in any case from the onFailure handler.

This can fix broken reconnect in some cases where internet connection was missing for some time.