### PR TITLE
Custom DNS client for connecting to centrifuge server

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -30,6 +30,7 @@ import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 import okio.ByteString;
 
+
 public class Client {
     private WebSocket ws;
     private final String endpoint;
@@ -248,9 +249,13 @@ public class Client {
 
         OkHttpClient.Builder okHttpBuilder = new OkHttpClient.Builder();
 
+        Dns dns = opts.getDns();
+        if (dns != null) {
+            okHttpBuilder.dns(dns::resolve);
+        }
+
         if (opts.getProxy() != null) {
             okHttpBuilder.proxy(opts.getProxy());
-
             if (this.opts.getProxyLogin() != null && this.opts.getProxyPassword() != null) {
                 okHttpBuilder.proxyAuthenticator((route, response) -> {
                     String credentials = Credentials.basic(opts.getProxyLogin(), opts.getProxyPassword());

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Dns.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Dns.java
@@ -1,0 +1,14 @@
+package io.github.centrifugal.centrifuge;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+
+/**
+ * Represents DNS client used to resolve addresses of a host.
+ */
+public interface Dns {
+
+    List<InetAddress> resolve(String host) throws UnknownHostException;
+
+}

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Options.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Options.java
@@ -140,4 +140,13 @@ public class Options {
     }
 
     private ConnectionTokenGetter tokenGetter;
+
+    public Dns getDns() {
+        return this.dns;
+    }
+    public void setDns(Dns dns) {
+        this.dns = dns;
+    }
+
+    private Dns dns;
 }


### PR DESCRIPTION
We need to connect to centrifuge server using custom DNS. Currently have to use custom build of this library to achieve this.

This PR adds ability to pass custom DNS client through `Options`.