### PR TITLE
Basic GitHub Actions for CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: Test workflow
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # Prevent duplicate builds on internal PRs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Compile library
+        run: ./gradlew :centrifuge:jar
+
+      - name: Run unit tests
+        run: ./gradlew :centrifuge:test
+
+  compileAndroidSample:
+    runs-on: ubuntu-latest
+    # Prevent duplicate builds on internal PRs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Compile Android Demo app
+        run: ./gradlew :demo:assembleDebug
+
+  compileJavaSample:
+    runs-on: ubuntu-latest
+    # Prevent duplicate builds on internal PRs.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Compile Java Example app
+        run: ./gradlew :example:assemble

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-          cache: gradle
 
       - name: Publish to Maven Central
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release workflow
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Publish to Maven Central
+        run: |
+          ./gradlew clean --no-daemon
+          ./gradlew publish --no-daemon --no-parallel
+          ./gradlew closeAndReleaseRepository
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME}}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD}}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.MAVEN_GPG_ID}}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.MAVEN_GPG_PASSWORD}}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.MAVEN_GPG_PRIVATE_KEY}}

--- a/README.md
+++ b/README.md
@@ -61,11 +61,19 @@ The protobuf definitions are located in `centrifuge/main/proto` directory.
 
 ## For maintainer
 
-### release
+### Automatic publishing
 
-Create configuration file `gradle.properties` in `GRADLE_USER_HOME`:
+1. Bump version in `publish-setup.gradle`. 
+2. Update changelog to reflect API and behavior changes, bugfixes. 
+3. Create new library tag. 
 
-```
+The release GitHub Action should now publish the library.
+
+### Manual publishing
+
+Do all steps from the automatic publishing. Create configuration file `gradle.properties` in `GRADLE_USER_HOME`:
+
+```properties
 signing.keyId=<LAST_8_SYMBOLS_OF_KEY_ID>
 signing.password=<PASSWORD>
 signing.secretKeyRingFile=/Path/to/.gnupg/secring.gpg
@@ -74,9 +82,9 @@ mavenCentralUsername=<USERNAME>
 mavenCentralPassword=<PASSWORD>
 ```
 
-Bump version in `publish-setup.gradle`. Write changelog. Create new library tag. Then run:
+Then run:
 
-```
+```shell
 ./gradlew publish --no-daemon --no-parallel
 ./gradlew closeAndReleaseRepository
 ```


### PR DESCRIPTION
Inspired by centrifuge-js, this PR adds 2 GitHub workflows.

1. `ci.yml` checks compilation of the library and samples, and runs unit tests
2. `release.yml` builds and publishes the library by tag to Maven Central

It basically resolves both #11 and #42 issues.

Will not be able to test release workflow. But Test workflow works:

<img width="317" alt="Screen Shot 2022-08-26 at 8 28 06 PM" src="https://user-images.githubusercontent.com/1446492/187006931-4ced1543-cc4f-4f8d-a87b-866303549b55.png">

