### PR TITLE
Include consumer proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,9 @@ Library available in Maven: https://search.maven.org/artifact/io.github.centrifu
 
 http://www.javadoc.io/doc/io.github.centrifugal/centrifuge-java
 
-## Before you start
+## Obfuscation with ProGuard
 
-Centrifuge-java library uses Protobuf library (Lite version) for client protocol. This fact and the fact that Protobuf Lite uses reflection internally can cause connection errors when releasing your application with Android shrinking and obfuscation features enabled. See [protocolbuffers/protobuf#6463](https://github.com/protocolbuffers/protobuf/issues/6463) for details. To deal with this add the following Proguard rule into `proguard-rules.pro` file in your project:
-
-```
--keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite {
-  <fields>;
-}
-```
+Centrifuge-java library uses Protobuf library (Lite version) for client protocol. This fact and the fact that Protobuf Lite uses reflection internally can cause connection errors when releasing your application with Android shrinking and obfuscation features enabled. See [protocolbuffers/protobuf#6463](https://github.com/protocolbuffers/protobuf/issues/6463) for details. To deal with this centrifuge-java comes with Proguard rules [included in the jar](centrifuge/src/main/resources/META-INF/proguard).
 
 More information [about Android shrinking](https://developer.android.com/studio/build/shrink-code).
 

--- a/centrifuge/src/main/resources/META-INF/proguard/centrifuge-java.pro
+++ b/centrifuge/src/main/resources/META-INF/proguard/centrifuge-java.pro
@@ -1,0 +1,4 @@
+# centrifuge-java relies on Protobuf JavaLite
+-keepclassmembers class * extends com.google.protobuf.GeneratedMessageLite {
+  <fields>;
+}


### PR DESCRIPTION
Android consumers don't need to add ProGuard rules manually. The library will supply the rules in jar file. This is a standard mechanism of ProGuard for library developers.

Tested this with Android app.