### PR TITLE
Fix unsubscribe request, bad protocol diffirentiation

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -361,7 +361,7 @@ public class Client {
         if (this.refreshRequired || (this.token == null && this.opts.getTokenGetter() != null)) {
             ConnectionTokenEvent connectionTokenEvent = new ConnectionTokenEvent();
             if (this.opts.getTokenGetter() == null) {
-                Client.this.listener.onError(Client.this, new ErrorEvent(new ConfigurationError(new Exception("tokenGetter function should be provided in Client options to handle token refresh, see Options.setTokenGetter"))));
+                this.listener.onError(Client.this, new ErrorEvent(new ConfigurationError(new Exception("tokenGetter function should be provided in Client options to handle token refresh, see Options.setTokenGetter"))));
                 this.processDisconnect(DISCONNECTED_UNAUTHORIZED, "unauthorized", false);
                 return;
             }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -278,7 +278,7 @@ public class Client {
                     } catch (Exception e) {
                         // Should never happen.
                         e.printStackTrace();
-                        Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol", false);
+                        Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol (open)", false);
                     }
                 });
             }
@@ -287,12 +287,19 @@ public class Client {
             public void onMessage(WebSocket webSocket, ByteString bytes) {
                 super.onMessage(webSocket, bytes);
                 Client.this.executor.submit(() -> {
+                    if (Client.this.getState() != ClientState.CONNECTING && Client.this.getState() != ClientState.CONNECTED) {
+                        return;
+                    }
+                    InputStream stream = new ByteArrayInputStream(bytes.toByteArray());
                     try {
-                        Client.this.handleConnectionMessage(bytes.toByteArray());
-                    } catch (Exception e) {
-                        // Should never happen.
+                        while (stream.available() > 0) {
+                            Protocol.Reply reply = Protocol.Reply.parseDelimitedFrom(stream);
+                            Client.this.processReply(reply);
+                        }
+                    } catch (IOException e) {
+                        // Should never happen. Corrupted server protocol data?
                         e.printStackTrace();
-                        Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol", false);
+                        Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol (message)", false);
                     }
                 });
             }
@@ -347,14 +354,16 @@ public class Client {
         });
     }
 
-    private void handleConnectionOpen() throws Exception {
+    private void handleConnectionOpen() {
         if (this.getState() != ClientState.CONNECTING) {
             return;
         }
         if (this.refreshRequired || (this.token == null && this.opts.getTokenGetter() != null)) {
             ConnectionTokenEvent connectionTokenEvent = new ConnectionTokenEvent();
             if (this.opts.getTokenGetter() == null) {
-                throw new Exception("tokenGetter function should be provided in Client options to handle token refresh, see Options.setTokenGetter");
+                Client.this.listener.onError(Client.this, new ErrorEvent(new ConfigurationError(new Exception("tokenGetter function should be provided in Client options to handle token refresh, see Options.setTokenGetter"))));
+                this.processDisconnect(DISCONNECTED_UNAUTHORIZED, "unauthorized", false);
+                return;
             }
             this.opts.getTokenGetter().getConnectionToken(connectionTokenEvent, (err, token) -> this.executor.submit(() -> {
                 if (Client.this.getState() != ClientState.CONNECTING) {
@@ -375,23 +384,6 @@ public class Client {
             }));
         } else {
             this.sendConnect();
-        }
-    }
-
-    private void handleConnectionMessage(byte[] bytes) {
-        if (this.getState() != ClientState.CONNECTING && this.getState() != ClientState.CONNECTED) {
-            return;
-        }
-        InputStream stream = new ByteArrayInputStream(bytes);
-        try {
-            while (stream.available() > 0) {
-                Protocol.Reply reply = Protocol.Reply.parseDelimitedFrom(stream);
-                this.processReply(reply);
-            }
-        } catch (IOException e) {
-            // Should never happen. Corrupted server protocol data?
-            e.printStackTrace();
-            this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol", false);
         }
     }
 
@@ -470,8 +462,7 @@ public class Client {
 
         Protocol.Command cmd = Protocol.Command.newBuilder()
                 .setId(this.getNextId())
-                .setMethod(Protocol.Command.MethodType.UNSUBSCRIBE)
-                .setParams(req.toByteString())
+                .setUnsubscribe(req)
                 .build();
 
         CompletableFuture<Protocol.Reply> f = new CompletableFuture<>();

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -303,15 +303,18 @@ public class Client {
                             // Should never happen. Corrupted server protocol data?
                             e.printStackTrace();
                             Client.this.listener.onError(Client.this, new ErrorEvent(new UnclassifiedError(e)));
-                            Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol (message)", false);
+                            Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol (proto)", false);
                             break;
                         }
                         try {
                             Client.this.processReply(reply);
                         } catch (Exception e) {
-                            // Should never happen. Most probably indicates an unexpected exception coming from user-level code.
+                            // Should never happen. Most probably indicates an unexpected exception coming from the user-level code.
+                            // Theoretically may indicate a bug of SDK also – stack trace will help here.
                             e.printStackTrace();
                             Client.this.listener.onError(Client.this, new ErrorEvent(new UnclassifiedError(e)));
+                            Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol (message)", false);
+                            break;
                         }
                     }
                 });

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -278,6 +278,7 @@ public class Client {
                     } catch (Exception e) {
                         // Should never happen.
                         e.printStackTrace();
+                        Client.this.listener.onError(Client.this, new ErrorEvent(new UnclassifiedError(e)));
                         Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol (open)", false);
                     }
                 });
@@ -299,6 +300,7 @@ public class Client {
                     } catch (IOException e) {
                         // Should never happen. Corrupted server protocol data?
                         e.printStackTrace();
+                        Client.this.listener.onError(Client.this, new ErrorEvent(new UnclassifiedError(e)));
                         Client.this.processDisconnect(DISCONNECTED_BAD_PROTOCOL, "bad protocol (message)", false);
                     }
                 });

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ConfigurationError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ConfigurationError.java
@@ -1,0 +1,13 @@
+package io.github.centrifugal.centrifuge;
+
+public class ConfigurationError extends Throwable {
+    private final Throwable error;
+
+    ConfigurationError(Throwable error) {
+        this.error = error;
+    }
+
+    public Throwable getError() {
+        return error;
+    }
+}

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/UnclassifiedError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/UnclassifiedError.java
@@ -1,0 +1,13 @@
+package io.github.centrifugal.centrifuge;
+
+public class UnclassifiedError extends Throwable {
+    private final Throwable error;
+
+    UnclassifiedError(Throwable error) {
+        this.error = error;
+    }
+
+    public Throwable getError() {
+        return error;
+    }
+}


### PR DESCRIPTION
Relates #49 

This pr:

1. Puts the source of bad protocol disconnect to reason to differentiate upon happening without finding a printed stacktrace. Also send the exception to `onError` listener.
2. Replace DISCONNECTED_BAD_PROTOCOL with DISCONNECTED_UNAUTHORIZED for the configuration error when TokenGetter not set. Also, send ConfigurationError to Error listener in this case.
3. Fix unsubscribe request which used legacy command.