### PR TITLE
And nullable/nonnullable annotation to improve Kotlin API

### DIFF
--- a/centrifuge/build.gradle
+++ b/centrifuge/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'com.google.protobuf:protobuf-javalite:3.20.1'
     implementation 'net.sourceforge.streamsupport:streamsupport-cfuture:1.7.0'
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
 
     testImplementation 'junit:junit:4.13.2'
 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -1038,19 +1038,15 @@ public class Client {
      * @param data:   a custom payload for RPC call.
      * @param cb:     will be called as soon as rpc response received or error happened.
      */
-    public void rpc(@Nullable String method, byte[] data, ResultCallback<RPCResult> cb) {
+    public void rpc(String method, byte[] data, ResultCallback<RPCResult> cb) {
         this.executor.submit(() -> Client.this.rpcSynchronized(method, data, cb));
     }
 
-    private void rpcSynchronized(@Nullable String method, byte[] data, ResultCallback<RPCResult> cb) {
-        Protocol.RPCRequest.Builder builder = Protocol.RPCRequest.newBuilder()
-                .setData(com.google.protobuf.ByteString.copyFrom(data));
-
-        if (method != null) {
-            builder.setMethod(method);
-        }
-
-        Protocol.RPCRequest req = builder.build();
+    private void rpcSynchronized(String method, byte[] data, ResultCallback<RPCResult> cb) {
+        Protocol.RPCRequest req = Protocol.RPCRequest.newBuilder()
+                .setData(com.google.protobuf.ByteString.copyFrom(data))
+                .setMethod(method)
+                .build();
 
         Protocol.Command cmd = Protocol.Command.newBuilder()
                 .setId(this.getNextId())

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -354,7 +354,7 @@ public class Client {
             }
 
             @Override
-            public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+            public void onFailure(WebSocket webSocket, Throwable t, @Nullable Response response) {
                 super.onFailure(webSocket, t, response);
                 try {
                     Client.this.executor.submit(() -> {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -1038,11 +1038,11 @@ public class Client {
      * @param data:   a custom payload for RPC call.
      * @param cb:     will be called as soon as rpc response received or error happened.
      */
-    public void rpc(String method, byte[] data, ResultCallback<RPCResult> cb) {
+    public void rpc(@Nullable String method, byte[] data, ResultCallback<RPCResult> cb) {
         this.executor.submit(() -> Client.this.rpcSynchronized(method, data, cb));
     }
 
-    private void rpcSynchronized(String method, byte[] data, ResultCallback<RPCResult> cb) {
+    private void rpcSynchronized(@Nullable String method, byte[] data, ResultCallback<RPCResult> cb) {
         Protocol.RPCRequest.Builder builder = Protocol.RPCRequest.newBuilder()
                 .setData(com.google.protobuf.ByteString.copyFrom(data));
 

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/CompletionCallback.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/CompletionCallback.java
@@ -1,8 +1,10 @@
 package io.github.centrifugal.centrifuge;
 
+import javax.annotation.Nullable;
+
 public interface CompletionCallback {
     /**
      * Called when operation done. Caller must check possible error (it's null in case of success).
      */
-    void onDone(Throwable e);
+    void onDone(@Nullable Throwable e);
 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Dns.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Dns.java
@@ -1,5 +1,7 @@
 package io.github.centrifugal.centrifuge;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
@@ -9,6 +11,7 @@ import java.util.List;
  */
 public interface Dns {
 
+    @NotNull
     List<InetAddress> resolve(String host) throws UnknownHostException;
 
 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Dns.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Dns.java
@@ -1,17 +1,17 @@
 package io.github.centrifugal.centrifuge;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.List;
+
+import javax.annotation.Nonnull;
 
 /**
  * Represents DNS client used to resolve addresses of a host.
  */
 public interface Dns {
 
-    @NotNull
+    @Nonnull
     List<InetAddress> resolve(String host) throws UnknownHostException;
 
 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/RefreshError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/RefreshError.java
@@ -1,13 +1,15 @@
 package io.github.centrifugal.centrifuge;
 
+import javax.annotation.Nullable;
+
 public class RefreshError extends Throwable {
     private final Throwable error;
 
-    RefreshError(Throwable error) {
+    RefreshError(@Nullable Throwable error) {
         this.error = error;
     }
 
-    public Throwable getError() {
+    public @Nullable Throwable getError() {
         return error;
     }
 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ResultCallback.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ResultCallback.java
@@ -1,5 +1,7 @@
 package io.github.centrifugal.centrifuge;
 
+import javax.annotation.Nullable;
+
 public interface ResultCallback<T> {
-    void onDone(Throwable e, T result);
+    void onDone(@Nullable Throwable e, @Nullable T result);
 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ServerSubscribedEvent.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ServerSubscribedEvent.java
@@ -1,7 +1,9 @@
 package io.github.centrifugal.centrifuge;
 
+import javax.annotation.Nullable;
+
 public class ServerSubscribedEvent {
-    ServerSubscribedEvent(String channel, Boolean wasRecovering, Boolean recovered, Boolean positioned, Boolean recoverable, StreamPosition streamPosition, byte[] data) {
+    ServerSubscribedEvent(String channel, Boolean wasRecovering, Boolean recovered, Boolean positioned, Boolean recoverable, @Nullable StreamPosition streamPosition, @Nullable byte[] data) {
         this.channel = channel;
         this.wasRecovering = wasRecovering;
         this.recovered = recovered;

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscribedEvent.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscribedEvent.java
@@ -1,7 +1,9 @@
 package io.github.centrifugal.centrifuge;
 
+import javax.annotation.Nullable;
+
 public class SubscribedEvent {
-    SubscribedEvent(Boolean wasRecovering, Boolean recovered, Boolean positioned, Boolean recoverable, StreamPosition streamPosition, byte[] data) {
+    SubscribedEvent(Boolean wasRecovering, Boolean recovered, Boolean positioned, Boolean recoverable, @Nullable StreamPosition streamPosition, @Nullable byte[] data) {
         this.wasRecovering = wasRecovering;
         this.recovered = recovered;
         this.data = data;

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
@@ -101,7 +101,7 @@ public class Subscription {
                 );
                 return;
             }
-            if (token.equals("")) {
+            if (token == null || token.equals("")) {
                 this.failUnauthorized(true);
                 return;
             }
@@ -110,8 +110,9 @@ public class Subscription {
                 if (Subscription.this.getState() != SubscriptionState.SUBSCRIBED) {
                     return;
                 }
-                if (error != null) {
-                    Subscription.this.listener.onError(Subscription.this, new SubscriptionErrorEvent(new SubscriptionRefreshError(error)));
+                Throwable errorOrNull = error != null ? error : (result == null ? new NullPointerException() : null);
+                if (errorOrNull != null) {
+                    Subscription.this.listener.onError(Subscription.this, new SubscriptionErrorEvent(new SubscriptionRefreshError(errorOrNull)));
                     if (error instanceof ReplyError) {
                         ReplyError e;
                         e = (ReplyError) error;
@@ -273,7 +274,7 @@ public class Subscription {
                     Subscription.this.scheduleResubscribe();
                     return;
                 }
-                if (token.equals("")) {
+                if (token == null || token.equals("")) {
                     Subscription.this.failUnauthorized(false);
                     return;
                 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/TokenCallback.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/TokenCallback.java
@@ -1,6 +1,8 @@
 package io.github.centrifugal.centrifuge;
 
+import javax.annotation.Nullable;
+
 public interface TokenCallback {
     /* Call this with exception or token. If called with null error and empty token then client considers access unauthorized */
-    void Done(Throwable e, String token);
+    void Done(@Nullable Throwable e, @Nullable String token);
 }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/package-info.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * File: package-info.java
+ * Make all method parameters @NonNull by default
+ */
+@ParametersAreNonnullByDefault
+package io.github.centrifugal.centrifuge;
+
+import javax.annotation.ParametersAreNonnullByDefault;


### PR DESCRIPTION
Right now, when used from Kotlin, library generates a lot of optional parameters - that's default behaviour for Java interop, as there's no build-in nullability checks.
```
object : SubscriptionEventListener() {
    override fun onSubscribed(sub: Subscription?, event: SubscribedEvent?) {
    }
```
With this PR I've added `ParametersAreNonnullByDefault` annotation to the lib package - this makes all arguments non nullable by default for IDEA linter and for Kotlin interop.

Also I've added a couple `Nullable` annotation for parameters that actually can be null - after adding `@ParametersAreNonnullByDefault`, IDEA showed me such places with warnings.

Also fixed a couple of warned placed