### PR TITLE
add cause to exception constructor

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ConfigurationError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ConfigurationError.java
@@ -5,6 +5,7 @@ public class ConfigurationError extends Throwable {
 
     ConfigurationError(Throwable error) {
         this.error = error;
+        this.initCause(error);
     }
 
     public Throwable getError() {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/RefreshError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/RefreshError.java
@@ -5,6 +5,7 @@ public class RefreshError extends Throwable {
 
     RefreshError(Throwable error) {
         this.error = error;
+        this.initCause(error);
     }
 
     public Throwable getError() {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionRefreshError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionRefreshError.java
@@ -5,6 +5,7 @@ public class SubscriptionRefreshError extends Throwable {
 
     SubscriptionRefreshError(Throwable error) {
         this.error = error;
+        this.initCause(error);
     }
 
     public Throwable getError() {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionSubscribeError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionSubscribeError.java
@@ -5,6 +5,7 @@ public class SubscriptionSubscribeError extends Throwable {
 
     SubscriptionSubscribeError(Throwable error) {
         this.error = error;
+        this.initCause(error);
     }
 
     public Throwable getError() {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionTokenError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionTokenError.java
@@ -5,6 +5,7 @@ public class SubscriptionTokenError extends Throwable {
 
     SubscriptionTokenError(Throwable error) {
         this.error = error;
+        this.initCause(error);
     }
 
     public Throwable getError() {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/TokenError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/TokenError.java
@@ -5,6 +5,7 @@ public class TokenError extends Throwable {
 
     TokenError(Throwable error) {
         this.error = error;
+        this.initCause(error);
     }
 
     public Throwable getError() {

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/UnclassifiedError.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/UnclassifiedError.java
@@ -5,6 +5,7 @@ public class UnclassifiedError extends Throwable {
 
     UnclassifiedError(Throwable error) {
         this.error = error;
+        this.initCause(error);
     }
 
     public Throwable getError() {


### PR DESCRIPTION
Let's say I have an exception in my network call during `SubscriptionTokenGetter.getSubscriptionToken`. I pass it to `cb.Done`, but when `SubscriptionEventListener.onError` is called, all I see in the stack trace is 

```
I/System.out: io.github.centrifugal.centrifuge.SubscriptionTokenError
I/System.out:     at io.github.centrifugal.centrifuge.Subscription.lambda$sendSubscribe$4$io-github-centrifugal-centrifuge-Subscription(Subscription.java:272)
I/System.out:     at io.github.centrifugal.centrifuge.Subscription$$ExternalSyntheticLambda6.run(Unknown Source:6)
I/System.out:     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:463)
...
```
It says nothing about the reason why my call failed. I could've check if it's `SubscriptionTokenError` and get `throwable`, but  this would require me to know about all the exceptions SDK could throw.

That's why when you have an exception, and your create an other one with your details of how it happened, you should fill `cause` with the original exception.

Here's how stacktrace looks like in this case:
```
I/System.out: io.github.centrifugal.centrifuge.SubscriptionTokenError
I/System.out:     at io.github.centrifugal.centrifuge.Subscription.lambda$sendSubscribe$4$io-github-centrifugal-centrifuge-Subscription(Subscription.java:273)
I/System.out:     at io.github.centrifugal.centrifuge.Subscription$$ExternalSyntheticLambda6.run(Unknown Source:6)
I/System.out:     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:463)
...

I/System.out: Caused by: java.lang.IllegalStateException: test exception message
I/System.out:     at com.test.centrifuge.CentrifugeManager$subscribeTo$1$subscription$1$1$getSubscriptionToken$1.invokeSuspend(CentrifugeManager.kt:139)
...
```
I guess you could remove `throwable` property from such exceptions, as it's available in cause - but it's up to you, as I guess it may change API.

Also, the difference between throwable and exception is that the former indicates that the current state of the application is faulty and cannot be recovered, so it must crash. For this reason nobody catches them - and catches Exception instead - it is better to get a crash in analytics to fix it than to ignore such an exception and get a malfunctioning application.

As your exceptions are not that critical, I would advise you to replace their superclass with exception - more for stability, since you're not really throwing them, so it shouldn't be a runtime problem unless someone would like to throw it at their own level to catch later.