### PR TITLE
Disconnect gracefully

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -226,7 +226,7 @@ public class Client {
             }
         }
 
-        this.ws.cancel();
+        this.ws.close(NORMAL_CLOSURE_STATUS, null);
     }
 
     private void _connect() {


### PR DESCRIPTION
Right now when I call `disconnect`, `EventListener.onError` is getting called with the following exception stacktrace:
```
java.net.SocketException: Socket closed
        at java.net.SocketInputStream.socketRead0(Native Method)
        at java.net.SocketInputStream.socketRead(SocketInputStream.java:118)
        at java.net.SocketInputStream.read(SocketInputStream.java:173)
        at java.net.SocketInputStream.read(SocketInputStream.java:143)
        at okio.InputStreamSource.read(JvmOkio.kt:94)
        at okio.AsyncTimeout$source$1.read(AsyncTimeout.kt:128)
        at okio.RealBufferedSource.request(RealBufferedSource.kt:206)
        at okio.RealBufferedSource.require(RealBufferedSource.kt:199)
        at okio.RealBufferedSource.readByte(RealBufferedSource.kt:209)
        at okhttp3.internal.ws.WebSocketReader.readHeader(WebSocketReader.kt:119)
        at okhttp3.internal.ws.WebSocketReader.processNextFrame(WebSocketReader.kt:102)
        at okhttp3.internal.ws.RealWebSocket.loopReader(RealWebSocket.kt:293)
        at okhttp3.internal.ws.RealWebSocket$connect$1.onResponse(RealWebSocket.kt:195)
        at okhttp3.internal.connection.RealCall$AsyncCall.run(RealCall.kt:519)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1137) 
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:637) 
        at java.lang.Thread.run(Thread.java:1012) 
```
It happens because of `WebSocketListener.onFailure` is getting called after `ws.cancel()` call - I haven't found any reports of such bug so maybe it's expected behaviour.

I checked iOS client source code, and it [seems](https://github.com/centrifugal/centrifuge-swift/blob/3ad4853959b21ecb9c330ec1472f4054fe127be7/Sources/SwiftCentrifuge/WebSocket.swift#L522) to be closing connection gracefully, e.g. with sending code `1000`, so I think it's ok for this client to do the same - this doesn't tiggers any failures from OkHttp.

