### PR TITLE
Add HTTP response code to ErrorEvent

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -368,6 +368,8 @@ public class Client {
                 try {
                     Client.this.executor.submit(() -> {
                         Client.this.handleConnectionError(t);
+                        Integer responseCode = (response != null) ? response.code() : null;
+                        listener.onError(Client.this, new ErrorEvent(t, responseCode));
                         Client.this.processDisconnect(CONNECTING_TRANSPORT_CLOSED, "transport closed", true);
                         if (Client.this.getState() == ClientState.CONNECTING) {
                             // We need to schedule reconnect from here, since onClosed won't be called

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -367,7 +367,6 @@ public class Client {
                 super.onFailure(webSocket, t, response);
                 try {
                     Client.this.executor.submit(() -> {
-                        Client.this.handleConnectionError(t);
                         Integer responseCode = (response != null) ? response.code() : null;
                         listener.onError(Client.this, new ErrorEvent(t, responseCode));
                         Client.this.processDisconnect(CONNECTING_TRANSPORT_CLOSED, "transport closed", true);

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ErrorEvent.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/ErrorEvent.java
@@ -2,12 +2,25 @@ package io.github.centrifugal.centrifuge;
 
 public class ErrorEvent {
     private final Throwable error;
+    private final Integer httpResponseCode;
 
     ErrorEvent(Throwable t) {
+        this(t, null);
+    }
+
+    ErrorEvent(Throwable t, Integer httpResponseCode) {
         this.error = t;
+        this.httpResponseCode = httpResponseCode;
     }
 
     public Throwable getError() {
         return error;
+    }
+
+    /**
+     * @return http response code or null if not an http error
+     */
+    public Integer getHttpResponseCode() {
+        return httpResponseCode;
     }
 }


### PR DESCRIPTION
## Description
Add HTTP response code to ErrorEvent.
There is an alternative approach to [this PR](https://github.com/centrifugal/centrifuge-java/pull/68).

In my opinion it would be better to pass whole response to ErrorEvent, but it will expose okhttp in centrifuge API.

## Why our project needs this
Our project needs an ability to change an endpoint in case of specific errors:
- UnknownHostException, SocketTimeoutException
- Some subset of HTTP response codes. For example 410

HTTP status codes currently does not exposed by centrifuge SDK, so we do not know when we need to change endpoint.