### PR TITLE
Replace cfuture with minifuture

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ The features implemented by this SDK can be found in [SDK feature matrix](https:
 
 Library available in Maven: https://search.maven.org/artifact/io.github.centrifugal/centrifuge-java
 
+This library depends on `streamsupport-minifuture`. In case your project has a dependency to `streamsupport-cfuture` and you have a class name conflicts, you can exclude minifuture safely. Example for Gradle: 
+
+```
+implementation('io.github.centrifugal:centrifuge-java:{version}') {
+    exclude group: 'net.sourceforge.streamsupport', module: 'streamsupport-minifuture'
+}
+```
+
 ## Javadoc online
 
 http://www.javadoc.io/doc/io.github.centrifugal/centrifuge-java

--- a/centrifuge/build.gradle
+++ b/centrifuge/build.gradle
@@ -25,7 +25,7 @@ publishing {
 dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.google.protobuf:protobuf-javalite:3.21.12'
-    implementation 'net.sourceforge.streamsupport:streamsupport-cfuture:1.7.0'
+    implementation 'net.sourceforge.streamsupport:streamsupport-minifuture:1.7.4'
 
     testImplementation 'junit:junit:4.13.2'
 }


### PR DESCRIPTION
## Description
`cfuture` is relatively small (66KB), but it depends on `streamsupport`, which is 958KB.
On the other hand `minifuture` is only 104KB and has no dependencies.

## What's been done
- Replace `cfuture` with `minifuture`
- Add workaround to Readme to mitigate class conflicts with streamsupport libs.