### PR TITLE
Delta improvements, introducing since option

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionOptions.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionOptions.java
@@ -90,9 +90,22 @@ public class SubscriptionOptions {
         return delta;
     }
 
+    // setDelta allows using delta compression for subscription. The delta compression
+    // must be also enabled on server side. The only value at this point is "fossil".
+    // See https://centrifugal.dev/docs/server/delta_compression.
     public void setDelta(String delta) {
         this.delta = delta;
     }
 
     private String delta = "";
+
+    public void setSince(StreamPosition streamPosition) {
+        this.since = streamPosition;
+    }
+
+    public StreamPosition getSince() {
+        return since;
+    }
+
+    private StreamPosition since;
 }

--- a/example/src/main/java/io/github/centrifugal/centrifuge/example/Main.java
+++ b/example/src/main/java/io/github/centrifugal/centrifuge/example/Main.java
@@ -152,7 +152,7 @@ public class Main {
         Subscription sub;
         SubscriptionOptions subOpts = new SubscriptionOptions();
         // You can set `delta` to `"fossil"` for using delta compression via
-        // `subOpts.setDelta("fossil")`;
+        // subOpts.setDelta("fossil");
         try {
             sub = client.newSubscription("chat:index", subOpts, subListener);
         } catch (DuplicateSubscriptionException e) {


### PR DESCRIPTION
This PR:

* adds delta support in recovered publications in addition to new publications added in #74 
* makes getPrevData/setPrevData private as should not be used from the outside
* adds `since` option for Subscription to provide starting `StreamPosition` for the Subscription.