### PR TITLE
Bump protobuf-javalite version

### DIFF
--- a/centrifuge/build.gradle
+++ b/centrifuge/build.gradle
@@ -24,7 +24,7 @@ publishing {
 
 dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    implementation 'com.google.protobuf:protobuf-javalite:3.21.12'
+    implementation 'com.google.protobuf:protobuf-javalite:3.25.5'
     implementation 'net.sourceforge.streamsupport:streamsupport-minifuture:1.7.4'
 
     testImplementation 'junit:junit:4.13.2'

--- a/publish-setup.gradle
+++ b/publish-setup.gradle
@@ -1,7 +1,7 @@
 allprojects {
     plugins.withId("com.vanniktech.maven.publish.base") {
         project.group = "io.github.centrifugal"
-        project.version = "0.4.2-RC2"
+        project.version = "0.4.2"
 
         mavenPublishing {
             publishToMavenCentral()

--- a/publish-setup.gradle
+++ b/publish-setup.gradle
@@ -1,7 +1,7 @@
 allprojects {
     plugins.withId("com.vanniktech.maven.publish.base") {
         project.group = "io.github.centrifugal"
-        project.version = "0.4.2-RC1"
+        project.version = "0.4.2-RC2"
 
         mavenPublishing {
             publishToMavenCentral()

--- a/publish-setup.gradle
+++ b/publish-setup.gradle
@@ -1,7 +1,7 @@
 allprojects {
     plugins.withId("com.vanniktech.maven.publish.base") {
         project.group = "io.github.centrifugal"
-        project.version = "0.4.2"
+        project.version = "0.4.2-RC1"
 
         mavenPublishing {
             publishToMavenCentral()


### PR DESCRIPTION
This helps to avoid [CVE-2024-7254](https://ossindex.sonatype.org/vulnerability/CVE-2024-7254) in Protobuf library.