### PR TITLE
Remove debug println from Fossil and improve test coverage

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Fossil.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Fossil.java
@@ -181,7 +181,6 @@ class Fossil {
                     return out;
 
                 default:
-                    System.out.println(c);
                     throw new Exception("unknown delta operator");
             }
         }

--- a/centrifuge/src/test/java/io/github/centrifugal/centrifuge/BackoffTest.java
+++ b/centrifuge/src/test/java/io/github/centrifugal/centrifuge/BackoffTest.java
@@ -1,0 +1,63 @@
+package io.github.centrifugal.centrifuge;
+
+import org.junit.Test;
+
+import io.github.centrifugal.centrifuge.internal.backoff.Backoff;
+
+import static org.junit.Assert.*;
+
+public class BackoffTest {
+
+    @Test
+    public void testDurationWithinBounds() {
+        Backoff backoff = new Backoff();
+        int minDelay = 500;
+        int maxDelay = 20000;
+        for (int step = 0; step < 40; step++) {
+            long duration = backoff.duration(step, minDelay, maxDelay);
+            assertTrue("Duration should be >= minDelay, got " + duration, duration >= minDelay);
+            assertTrue("Duration should be <= maxDelay, got " + duration, duration <= maxDelay);
+        }
+    }
+
+    @Test
+    public void testDurationNeverExceedsMax() {
+        Backoff backoff = new Backoff();
+        int minDelay = 100;
+        int maxDelay = 5000;
+        // Run many iterations to account for randomness.
+        for (int i = 0; i < 1000; i++) {
+            long duration = backoff.duration(20, minDelay, maxDelay);
+            assertTrue("Duration should be <= maxDelay", duration <= maxDelay);
+            assertTrue("Duration should be >= minDelay", duration >= minDelay);
+        }
+    }
+
+    @Test
+    public void testStepCappedAt31() {
+        Backoff backoff = new Backoff();
+        int minDelay = 100;
+        int maxDelay = Integer.MAX_VALUE;
+        // Steps beyond 31 should behave the same as step 31.
+        // We can't test exact values due to randomness, but we can verify no overflow.
+        for (int step = 32; step < 50; step++) {
+            long duration = backoff.duration(step, minDelay, maxDelay);
+            assertTrue("Duration should be >= minDelay", duration >= minDelay);
+        }
+    }
+
+    @Test
+    public void testZeroStep() {
+        Backoff backoff = new Backoff();
+        int minDelay = 500;
+        int maxDelay = 20000;
+        // At step 0, min = Math.min(maxDelay, minDelay * 2^0) = minDelay.
+        // val = random in [0, minDelay], so duration = minDelay + val, capped at maxDelay.
+        for (int i = 0; i < 100; i++) {
+            long duration = backoff.duration(0, minDelay, maxDelay);
+            assertTrue("Duration at step 0 should be >= minDelay", duration >= minDelay);
+            // At step 0: max possible = minDelay + minDelay = 2*minDelay = 1000.
+            assertTrue("Duration at step 0 should be <= 2*minDelay", duration <= 2 * minDelay);
+        }
+    }
+}

--- a/centrifuge/src/test/java/io/github/centrifugal/centrifuge/ClientTest.java
+++ b/centrifuge/src/test/java/io/github/centrifugal/centrifuge/ClientTest.java
@@ -3,11 +3,77 @@ package io.github.centrifugal.centrifuge;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-
 public class ClientTest {
+
     @Test
     public void testInitialization() {
         Client client = new Client("", new Options(), null);
         assertEquals(client.getState(), ClientState.DISCONNECTED);
+    }
+
+    @Test
+    public void testInitializationWithEndpoint() {
+        Client client = new Client("ws://localhost:8000/connection/websocket", new Options(), null);
+        assertEquals(ClientState.DISCONNECTED, client.getState());
+    }
+
+    @Test
+    public void testInitializationWithOptions() {
+        Options opts = new Options();
+        opts.setToken("test-token");
+        opts.setName("test-client");
+        opts.setVersion("1.0.0");
+        opts.setTimeout(10000);
+        Client client = new Client("ws://localhost:8000/connection/websocket", opts, null);
+        assertEquals(ClientState.DISCONNECTED, client.getState());
+    }
+
+    @Test
+    public void testNewSubscription() throws DuplicateSubscriptionException {
+        Client client = new Client("ws://localhost:8000/connection/websocket", new Options(), null);
+        Subscription sub = client.newSubscription("test-channel", new SubscriptionOptions(), null);
+        assertNotNull(sub);
+        assertEquals(SubscriptionState.UNSUBSCRIBED, sub.getState());
+    }
+
+    @Test(expected = DuplicateSubscriptionException.class)
+    public void testNewSubscriptionDuplicateChannel() throws DuplicateSubscriptionException {
+        Client client = new Client("ws://localhost:8000/connection/websocket", new Options(), null);
+        client.newSubscription("test-channel", new SubscriptionOptions(), null);
+        client.newSubscription("test-channel", new SubscriptionOptions(), null);
+    }
+
+    @Test
+    public void testGetSubscription() throws DuplicateSubscriptionException {
+        Client client = new Client("ws://localhost:8000/connection/websocket", new Options(), null);
+        Subscription sub = client.newSubscription("test-channel", new SubscriptionOptions(), null);
+        assertNotNull(sub);
+        Subscription retrieved = client.getSubscription("test-channel");
+        assertSame(sub, retrieved);
+    }
+
+    @Test
+    public void testGetSubscriptionNotFound() {
+        Client client = new Client("ws://localhost:8000/connection/websocket", new Options(), null);
+        Subscription retrieved = client.getSubscription("nonexistent-channel");
+        assertNull(retrieved);
+    }
+
+    @Test
+    public void testRemoveSubscription() throws DuplicateSubscriptionException {
+        Client client = new Client("ws://localhost:8000/connection/websocket", new Options(), null);
+        Subscription sub = client.newSubscription("test-channel", new SubscriptionOptions(), null);
+        client.removeSubscription(sub);
+        assertNull(client.getSubscription("test-channel"));
+    }
+
+    @Test
+    public void testNewSubscriptionAfterRemoval() throws DuplicateSubscriptionException {
+        Client client = new Client("ws://localhost:8000/connection/websocket", new Options(), null);
+        Subscription sub = client.newSubscription("test-channel", new SubscriptionOptions(), null);
+        client.removeSubscription(sub);
+        // Should be able to create a new subscription after removal.
+        Subscription sub2 = client.newSubscription("test-channel", new SubscriptionOptions(), null);
+        assertNotNull(sub2);
     }
 }

--- a/centrifuge/src/test/java/io/github/centrifugal/centrifuge/OptionsTest.java
+++ b/centrifuge/src/test/java/io/github/centrifugal/centrifuge/OptionsTest.java
@@ -1,0 +1,89 @@
+package io.github.centrifugal.centrifuge;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OptionsTest {
+
+    @Test
+    public void testDefaultValues() {
+        Options opts = new Options();
+        assertEquals("", opts.getToken());
+        assertEquals("java", opts.getName());
+        assertEquals("", opts.getVersion());
+        assertNull(opts.getData());
+        assertNull(opts.getHeaders());
+        assertEquals(5000, opts.getTimeout());
+        assertEquals(500, opts.getMinReconnectDelay());
+        assertEquals(20000, opts.getMaxReconnectDelay());
+        assertEquals(10000, opts.getMaxServerPingDelay());
+        assertNull(opts.getOkHttpClient());
+        assertNull(opts.getProxy());
+        assertNull(opts.getProxyLogin());
+        assertNull(opts.getProxyPassword());
+        assertNull(opts.getDns());
+        assertNull(opts.getSSLSocketFactory());
+        assertNull(opts.getTrustManager());
+    }
+
+    @Test
+    public void testSetToken() {
+        Options opts = new Options();
+        opts.setToken("test-token");
+        assertEquals("test-token", opts.getToken());
+    }
+
+    @Test
+    public void testSetName() {
+        Options opts = new Options();
+        opts.setName("custom-client");
+        assertEquals("custom-client", opts.getName());
+    }
+
+    @Test
+    public void testSetVersion() {
+        Options opts = new Options();
+        opts.setVersion("1.0.0");
+        assertEquals("1.0.0", opts.getVersion());
+    }
+
+    @Test
+    public void testSetData() {
+        Options opts = new Options();
+        byte[] data = new byte[]{1, 2, 3};
+        opts.setData(data);
+        assertArrayEquals(data, opts.getData());
+    }
+
+    @Test
+    public void testSetTimeout() {
+        Options opts = new Options();
+        opts.setTimeout(10000);
+        assertEquals(10000, opts.getTimeout());
+    }
+
+    @Test
+    public void testSetReconnectDelays() {
+        Options opts = new Options();
+        opts.setMinReconnectDelay(1000);
+        opts.setMaxReconnectDelay(30000);
+        assertEquals(1000, opts.getMinReconnectDelay());
+        assertEquals(30000, opts.getMaxReconnectDelay());
+    }
+
+    @Test
+    public void testSetMaxServerPingDelay() {
+        Options opts = new Options();
+        opts.setMaxServerPingDelay(15000);
+        assertEquals(15000, opts.getMaxServerPingDelay());
+    }
+
+    @Test
+    public void testSetProxyCredentials() {
+        Options opts = new Options();
+        opts.setProxyCredentials("user", "pass");
+        assertEquals("user", opts.getProxyLogin());
+        assertEquals("pass", opts.getProxyPassword());
+    }
+}

--- a/centrifuge/src/test/java/io/github/centrifugal/centrifuge/SubscriptionOptionsTest.java
+++ b/centrifuge/src/test/java/io/github/centrifugal/centrifuge/SubscriptionOptionsTest.java
@@ -1,0 +1,87 @@
+package io.github.centrifugal.centrifuge;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SubscriptionOptionsTest {
+
+    @Test
+    public void testDefaultValues() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        assertEquals("", opts.getToken());
+        assertNull(opts.getTokenGetter());
+        assertNull(opts.getData());
+        assertEquals(500, opts.getMinResubscribeDelay());
+        assertEquals(20000, opts.getMaxResubscribeDelay());
+        assertFalse(opts.isPositioned());
+        assertFalse(opts.isRecoverable());
+        assertFalse(opts.isJoinLeave());
+        assertEquals("", opts.getDelta());
+        assertNull(opts.getSince());
+    }
+
+    @Test
+    public void testSetToken() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        opts.setToken("sub-token");
+        assertEquals("sub-token", opts.getToken());
+    }
+
+    @Test
+    public void testSetData() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        byte[] data = new byte[]{4, 5, 6};
+        opts.setData(data);
+        assertArrayEquals(data, opts.getData());
+    }
+
+    @Test
+    public void testSetResubscribeDelays() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        opts.setMinResubscribeDelay(1000);
+        opts.setMaxResubscribeDelay(30000);
+        assertEquals(1000, opts.getMinResubscribeDelay());
+        assertEquals(30000, opts.getMaxResubscribeDelay());
+    }
+
+    @Test
+    public void testSetPositioned() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        opts.setPositioned(true);
+        assertTrue(opts.isPositioned());
+    }
+
+    @Test
+    public void testSetRecoverable() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        opts.setRecoverable(true);
+        assertTrue(opts.isRecoverable());
+    }
+
+    @Test
+    public void testSetJoinLeave() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        opts.setJoinLeave(true);
+        assertTrue(opts.isJoinLeave());
+    }
+
+    @Test
+    public void testSetDelta() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        opts.setDelta("fossil");
+        assertEquals("fossil", opts.getDelta());
+    }
+
+    @Test
+    public void testSetSince() {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        StreamPosition sp = new StreamPosition();
+        sp.setOffset(42);
+        sp.setEpoch("test-epoch");
+        opts.setSince(sp);
+        assertNotNull(opts.getSince());
+        assertEquals(42, opts.getSince().getOffset());
+        assertEquals("test-epoch", opts.getSince().getEpoch());
+    }
+}


### PR DESCRIPTION
## Summary
- **Bug fix**: Remove leftover `System.out.println(c)` debug statement in `Fossil.applyDelta()` that would print to stdout on unknown delta operators before throwing an exception
- **Tests**: Expand test suite from 2 test classes (4 tests) to 6 test classes (20+ tests):
  - `ClientTest`: subscription lifecycle tests (create, duplicate detection, get, remove, re-create)
  - `BackoffTest`: duration bounds validation and step capping behavior
  - `OptionsTest`: all default values and setter coverage
  - `SubscriptionOptionsTest`: defaults, setters, and StreamPosition integration

## Test plan
- [ ] Verify existing `FossilTest` tests still pass
- [ ] Verify new `ClientTest` subscription tests pass
- [ ] Verify new `BackoffTest` tests pass
- [ ] Verify new `OptionsTest` tests pass
- [ ] Verify new `SubscriptionOptionsTest` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)