### PR TITLE
Do not dispose dispatcher of a user-supplied OkHttpClient on reconnect and close

### DIFF
--- a/centrifuge/src/integrationTest/java/io/github/centrifugal/centrifuge/ReconnectIntegrationTest.java
+++ b/centrifuge/src/integrationTest/java/io/github/centrifugal/centrifuge/ReconnectIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.github.centrifugal.centrifuge;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -11,6 +12,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,6 +25,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -95,6 +102,62 @@ public class ReconnectIntegrationTest extends IntegrationTestBase {
         assertTrue("got onConnecting events: " + connectingCount.get(),
                 connectingCount.get() >= 2);
         assertEquals(2, connectedCount.get());
+    }
+
+    @Test(timeout = 20_000)
+    public void testUserSuppliedOkHttpClientSurvivesReconnectAndClose() throws Exception {
+        String user = "user-" + UUID.randomUUID();
+        OkHttpClient userClient = new OkHttpClient();
+
+        Captured<ConnectedEvent> firstConnected = new Captured<>();
+        Captured<ConnectedEvent> reconnected = new Captured<>();
+
+        Options opts = fastReconnectOpts(user);
+        opts.setOkHttpClient(userClient);
+
+        client = new Client(endpoint(), opts, new EventListener() {
+            @Override public void onConnected(Client c, ConnectedEvent e) {
+                if (!firstConnected.isSet()) firstConnected.set(e);
+                else if (!reconnected.isSet()) reconnected.set(e);
+            }
+        });
+        client.connect();
+        firstConnected.await("first connect");
+
+        api.disconnectUser(user, CODE_DISCONNECT_RECONNECT, "test");
+        reconnected.await("reconnected");
+
+        // Transports are derived from the user's client via newBuilder(), which
+        // shares its Dispatcher and ConnectionPool — reconnect must not dispose
+        // them (#87).
+        assertFalse("reconnect must not shut down the user client's dispatcher executor",
+                userClient.dispatcher().executorService().isShutdown());
+
+        // Async calls on the user's client still execute after the reconnect;
+        // enqueue() goes through the dispatcher executor the disposal used to kill.
+        CountDownLatch callResponded = new CountDownLatch(1);
+        AtomicReference<IOException> callFailure = new AtomicReference<>();
+        String apiUrl = System.getProperty("centrifuge.apiUrl", "http://localhost:8000/api");
+        userClient.newCall(new Request.Builder().url(apiUrl).build()).enqueue(new Callback() {
+            @Override public void onFailure(Call call, IOException e) {
+                callFailure.set(e);
+                callResponded.countDown();
+            }
+
+            @Override public void onResponse(Call call, Response response) {
+                response.close();
+                callResponded.countDown();
+            }
+        });
+        awaitLatch(callResponded, "async call on user client");
+        assertNull("async call on user client must not fail: " + callFailure.get(),
+                callFailure.get());
+
+        // close() must leave the user-supplied client's resources alone too.
+        client.close(2000);
+        client = null;
+        assertFalse("close must not shut down the user client's dispatcher executor",
+                userClient.dispatcher().executorService().isShutdown());
     }
 
     @Test(timeout = 15_000)

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -182,10 +182,11 @@ public class Client {
                     Client.this.ws.cancel();
                 }
                 // Release dispatcher threads + pooled connections on transports
-                // we built ourselves. A user-supplied OkHttpClient is left
-                // alone — we never own its lifecycle.
+                // we built from scratch. When the user supplied a base client,
+                // transports derived from it via newBuilder() share the user's
+                // Dispatcher and ConnectionPool — we never own those (#87).
                 if (Client.this.httpClient != null
-                        && Client.this.httpClient != Client.this.opts.getOkHttpClient()) {
+                        && Client.this.opts.getOkHttpClient() == null) {
                     Client.this.httpClient.dispatcher().executorService().shutdown();
                     Client.this.httpClient.connectionPool().evictAll();
                 }
@@ -283,12 +284,17 @@ public class Client {
             this.ws.cancel();
         }
 
-        // If we previously built our own OkHttpClient, release its dispatcher
-        // threads and pooled connections before building a new one. When the
-        // user supplied the client (this.httpClient == opts.getOkHttpClient())
-        // we never own it, so we must not shut it down.
+        // If we previously built our own OkHttpClient from scratch, release its
+        // dispatcher threads and pooled connections before building a new one.
+        // When the user supplied a base client we derive each transport from it
+        // via newBuilder(), which shares the user's Dispatcher and
+        // ConnectionPool: shutting those down would kill the executor behind
+        // the user's client and behind the very transport we are about to
+        // build, permanently rejecting all of their calls and our future
+        // reconnects (#87). Only transports built from scratch own their
+        // resources.
         boolean previousWasOurs = this.httpClient != null
-                && this.httpClient != opts.getOkHttpClient();
+                && opts.getOkHttpClient() == null;
         OkHttpClient previousHttpClient = previousWasOurs ? this.httpClient : null;
 
         OkHttpClient.Builder okHttpBuilder;

--- a/centrifuge/src/test/java/io/github/centrifugal/centrifuge/ClientTest.java
+++ b/centrifuge/src/test/java/io/github/centrifugal/centrifuge/ClientTest.java
@@ -1,5 +1,9 @@
 package io.github.centrifugal.centrifuge;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.OkHttpClient;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -75,5 +79,40 @@ public class ClientTest {
         // Should be able to create a new subscription after removal.
         Subscription sub2 = client.newSubscription("test-channel", new SubscriptionOptions(), null);
         assertNotNull(sub2);
+    }
+
+    @Test(timeout = 10_000)
+    public void testUserSuppliedOkHttpClientNotDisposedOnReconnect() throws Exception {
+        OkHttpClient userClient = new OkHttpClient();
+
+        Options opts = new Options();
+        opts.setOkHttpClient(userClient);
+        opts.setMinReconnectDelay(10);
+        opts.setMaxReconnectDelay(20);
+
+        // Port 1 is never bound: connects are refused immediately, which drives
+        // the reconnect path (and its transport disposal) without any server.
+        CountDownLatch twoFailedAttempts = new CountDownLatch(2);
+        Client client = new Client("ws://127.0.0.1:1/connection/websocket", opts, new EventListener() {
+            @Override
+            public void onError(Client c, ErrorEvent e) {
+                twoFailedAttempts.countDown();
+            }
+        });
+        client.connect();
+        assertTrue("expected at least two failed connect attempts",
+                twoFailedAttempts.await(8, TimeUnit.SECONDS));
+
+        // Transports are derived from the user's client via newBuilder(), which
+        // shares its Dispatcher and ConnectionPool. The reconnect path must not
+        // dispose them (#87): with the bug, the shared executor is already shut
+        // down by the second attempt, every call on the user's client fails with
+        // "executor rejected" and the SDK itself can never reconnect.
+        assertFalse("user client's dispatcher executor must stay usable",
+                userClient.dispatcher().executorService().isShutdown());
+
+        client.close(1000);
+        assertFalse("close() must not dispose a user-supplied client's executor",
+                userClient.dispatcher().executorService().isShutdown());
     }
 }


### PR DESCRIPTION
Fixes #87.

## Problem

When `Options.okHttpClient` is set, every (re)connect derives the transport client from it via `opts.getOkHttpClient().newBuilder()`. `newBuilder()` shares the `Dispatcher` (and its `ExecutorService`) and the `ConnectionPool` by reference, so the previous-transport disposal introduced in #86:

```java
previousHttpClient.dispatcher().executorService().shutdown();
previousHttpClient.connectionPool().evictAll();
```

shuts down the **user's** executor on the first reconnect — the instance-identity guard (`previousHttpClient != opts.getOkHttpClient()`) passes because each derived generation is a different instance, even though it carries the user's dispatcher. After that, every async call on the user's client fails immediately with `InterruptedIOException: executor rejected` until process restart, and the SDK itself can never reconnect either, since all subsequent generations share the same dead executor. #86 itself states the disposal should run "only when the previous client was one we built (never on a user-supplied client)" — this PR makes the implementation match that intent.

## Change

Ownership is now derived from how the transport was built, not from instance identity: previous transports are disposed only when `opts.getOkHttpClient() == null` (built from scratch, so each generation owns its `Dispatcher`/`ConnectionPool`). When the user supplied a base client there is nothing per-generation to release — all generations share the user's dispatcher and pool, and `ws.cancel()` already covers the old socket. The same guard is applied in `close()`.

The lib-built path keeps the #86 disposal behavior unchanged, so its thread-leak fix is unaffected. No public API change (`api.txt` untouched).

## Tests

- **Unit** — `ClientTest.testUserSuppliedOkHttpClientNotDisposedOnReconnect`: drives the reconnect path against a refused localhost port, no server needed. Red on master (`user client's dispatcher executor must stay usable`), green with the fix.
- **Integration** — `ReconnectIntegrationTest.testUserSuppliedOkHttpClientSurvivesReconnectAndClose`: real server-side disconnect with `Options.okHttpClient` set; asserts the user's executor stays alive after the reconnect, an async call on the user's client still executes, and `close()` leaves the client alone as well. This also closes the coverage gap noted in #87 — the existing reconnect tests only exercise the lib-built-client path.

Verified locally with JDK 17: `:centrifuge:test` green including the new unit test (and red on master), `:centrifuge:compileIntegrationTestJava` green. I could not run the docker-based integration job locally (no docker on this machine) — relying on the CI `integrationTest` job for that.
