### PR TITLE
Support publication filtering by tags

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/FilterNode.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/FilterNode.java
@@ -1,0 +1,30 @@
+package io.github.centrifugal.centrifuge;
+
+import io.github.centrifugal.centrifuge.internal.protocol.Protocol;
+
+/**
+ * A node in a publication tags-filter expression tree, used for server-side
+ * publication filtering. Build instances with {@link FilterNodeBuilder} and pass
+ * the result to {@link SubscriptionOptions#setTagsFilter} or
+ * {@link Subscription#setTagsFilter}.
+ *
+ * <p>A filter is either a leaf node (a comparison such as {@code ticker == "AAPL"})
+ * or a logical node combining child nodes with and/or/not. The server evaluates
+ * the filter against each publication's tags and delivers only matching
+ * publications. See
+ * <a href="https://centrifugal.dev/docs/server/publication_filtering">publication filtering</a>.
+ *
+ * <p>Publication filtering must be enabled for the namespace on the server
+ * ({@code allow_tags_filter}) and cannot be combined with delta compression.
+ */
+public final class FilterNode {
+    private final Protocol.FilterNode node;
+
+    FilterNode(Protocol.FilterNode node) {
+        this.node = node;
+    }
+
+    Protocol.FilterNode getProtoNode() {
+        return node;
+    }
+}

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/FilterNodeBuilder.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/FilterNodeBuilder.java
@@ -1,0 +1,126 @@
+package io.github.centrifugal.centrifuge;
+
+import java.util.Arrays;
+
+import io.github.centrifugal.centrifuge.internal.protocol.Protocol;
+
+/**
+ * Helpers for building {@link FilterNode} expressions for server-side publication
+ * filtering based on publication tags. Comparison helpers create leaf nodes;
+ * {@link #and}, {@link #or} and {@link #not} combine them.
+ *
+ * <pre>
+ * // (ticker == "AAPL") AND (price &gt;= "100") AND (source in ["NASDAQ", "NYSE"])
+ * FilterNode filter = FilterNodeBuilder.and(
+ *         FilterNodeBuilder.eq("ticker", "AAPL"),
+ *         FilterNodeBuilder.gte("price", "100"),
+ *         FilterNodeBuilder.in("source", "NASDAQ", "NYSE"));
+ * </pre>
+ */
+public final class FilterNodeBuilder {
+
+    private FilterNodeBuilder() {
+    }
+
+    private static FilterNode leaf(String key, String cmp, String val) {
+        Protocol.FilterNode.Builder b = Protocol.FilterNode.newBuilder().setKey(key).setCmp(cmp);
+        if (val != null) {
+            b.setVal(val);
+        }
+        return new FilterNode(b.build());
+    }
+
+    private static FilterNode set(String key, String cmp, String[] vals) {
+        Protocol.FilterNode.Builder b = Protocol.FilterNode.newBuilder().setKey(key).setCmp(cmp);
+        b.addAllVals(Arrays.asList(vals));
+        return new FilterNode(b.build());
+    }
+
+    private static FilterNode logical(String op, FilterNode[] nodes) {
+        Protocol.FilterNode.Builder b = Protocol.FilterNode.newBuilder().setOp(op);
+        for (FilterNode n : nodes) {
+            b.addNodes(n.getProtoNode());
+        }
+        return new FilterNode(b.build());
+    }
+
+    /** Tag {@code key} equals {@code val}. */
+    public static FilterNode eq(String key, String val) {
+        return leaf(key, "eq", val);
+    }
+
+    /** Tag {@code key} does not equal {@code val}. */
+    public static FilterNode neq(String key, String val) {
+        return leaf(key, "neq", val);
+    }
+
+    /** Tag {@code key} is one of {@code vals}. */
+    public static FilterNode in(String key, String... vals) {
+        return set(key, "in", vals);
+    }
+
+    /** Tag {@code key} is not one of {@code vals}. */
+    public static FilterNode nin(String key, String... vals) {
+        return set(key, "nin", vals);
+    }
+
+    /** Tag {@code key} exists. */
+    public static FilterNode exists(String key) {
+        return leaf(key, "ex", null);
+    }
+
+    /** Tag {@code key} does not exist. */
+    public static FilterNode notExists(String key) {
+        return leaf(key, "nex", null);
+    }
+
+    /** String tag {@code key} starts with {@code val}. */
+    public static FilterNode startsWith(String key, String val) {
+        return leaf(key, "sw", val);
+    }
+
+    /** String tag {@code key} ends with {@code val}. */
+    public static FilterNode endsWith(String key, String val) {
+        return leaf(key, "ew", val);
+    }
+
+    /** String tag {@code key} contains {@code val}. */
+    public static FilterNode contains(String key, String val) {
+        return leaf(key, "ct", val);
+    }
+
+    /** Numeric tag {@code key} is greater than {@code val}. */
+    public static FilterNode gt(String key, String val) {
+        return leaf(key, "gt", val);
+    }
+
+    /** Numeric tag {@code key} is greater than or equal to {@code val}. */
+    public static FilterNode gte(String key, String val) {
+        return leaf(key, "gte", val);
+    }
+
+    /** Numeric tag {@code key} is less than {@code val}. */
+    public static FilterNode lt(String key, String val) {
+        return leaf(key, "lt", val);
+    }
+
+    /** Numeric tag {@code key} is less than or equal to {@code val}. */
+    public static FilterNode lte(String key, String val) {
+        return leaf(key, "lte", val);
+    }
+
+    /** All {@code nodes} must match. */
+    public static FilterNode and(FilterNode... nodes) {
+        return logical("and", nodes);
+    }
+
+    /** At least one of {@code nodes} must match. */
+    public static FilterNode or(FilterNode... nodes) {
+        return logical("or", nodes);
+    }
+
+    /** Inverts {@code node}. */
+    public static FilterNode not(FilterNode node) {
+        return logical("not", new FilterNode[]{node});
+    }
+}

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
@@ -27,6 +27,7 @@ public class Subscription {
     private int resubscribeAttempts = 0;
     private String token;
     private com.google.protobuf.ByteString data;
+    private FilterNode tagsFilter;
     private boolean deltaNegotiated;
     private byte[] prevData;
     // Numeric channel ID assigned by the server when channel compaction is
@@ -48,6 +49,7 @@ public class Subscription {
         if (opts.getData() != null) {
             this.data = com.google.protobuf.ByteString.copyFrom(opts.getData());
         }
+        this.tagsFilter = opts.getTagsFilter();
         this.prevData = null;
         this.deltaNegotiated = false;
         if (opts.getSince() != null) {
@@ -275,6 +277,20 @@ public class Subscription {
         }
     }
 
+    /**
+     * Set the server-side publication tags filter. Applied on the next subscribe
+     * attempt, not the current one. Pass {@code null} to clear it. Cannot be
+     * combined with delta compression. Build with {@link FilterNodeBuilder}.
+     *
+     * @throws IllegalStateException if delta compression is enabled for this subscription.
+     */
+    public void setTagsFilter(FilterNode tagsFilter) {
+        if (tagsFilter != null && this.opts.getDelta() != null && !this.opts.getDelta().isEmpty()) {
+            throw new IllegalStateException("cannot use delta and tags filter together");
+        }
+        this.tagsFilter = tagsFilter;
+    }
+
     public void subscribe() {
         this.client.getExecutor().submit(() -> {
             if (Subscription.this.getState() == SubscriptionState.SUBSCRIBED || Subscription.this.getState() == SubscriptionState.SUBSCRIBING) {
@@ -311,6 +327,9 @@ public class Subscription {
         builder.setRecoverable(this.opts.isRecoverable());
         builder.setJoinLeave(this.opts.isJoinLeave());
         builder.setDelta(this.opts.getDelta());
+        if (this.tagsFilter != null) {
+            builder.setTf(this.tagsFilter.getProtoNode());
+        }
         // Always offer channel compaction: when the server supports and allows it,
         // the subscribe result carries a numeric channel ID and subsequent pushes
         // use that ID instead of the string channel name.

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionOptions.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/SubscriptionOptions.java
@@ -99,6 +99,22 @@ public class SubscriptionOptions {
 
     private String delta = "";
 
+    public FilterNode getTagsFilter() {
+        return tagsFilter;
+    }
+
+    /**
+     * Set a server-side publication filter based on publication tags. When set, the
+     * server delivers only publications whose tags match the filter. Must be enabled
+     * for the namespace on the server ({@code allow_tags_filter}) and cannot be
+     * combined with delta compression. Build with {@link FilterNodeBuilder}.
+     */
+    public void setTagsFilter(FilterNode tagsFilter) {
+        this.tagsFilter = tagsFilter;
+    }
+
+    private FilterNode tagsFilter;
+
     public SubscriptionStateGetter getStateGetter() {
         return stateGetter;
     }

--- a/centrifuge/src/test/java/io/github/centrifugal/centrifuge/FilterTest.java
+++ b/centrifuge/src/test/java/io/github/centrifugal/centrifuge/FilterTest.java
@@ -1,0 +1,186 @@
+package io.github.centrifugal.centrifuge;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import io.github.centrifugal.centrifuge.internal.protocol.Protocol;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests for publication filtering (server-side filtering by publication tags).
+ * The {@link FilterNodeBuilder} helpers build a protocol FilterNode tree; the
+ * subscribe request carries it in the {@code tf} field. The feature requires
+ * Centrifugo PRO / namespace config, so wire-level behavior is exercised against
+ * the in-process {@link FakeCentrifugoServer}.
+ */
+public class FilterTest {
+
+    private FakeCentrifugoServer server;
+
+    @Before
+    public void setUp() throws IOException {
+        server = new FakeCentrifugoServer();
+        server.start();
+    }
+
+    @After
+    public void tearDown() {
+        server.stop();
+    }
+
+    @Test
+    public void testBuilderLeafNodes() {
+        assertEquals("eq", FilterNodeBuilder.eq("ticker", "AAPL").getProtoNode().getCmp());
+        assertEquals("AAPL", FilterNodeBuilder.eq("ticker", "AAPL").getProtoNode().getVal());
+        assertEquals("neq", FilterNodeBuilder.neq("source", "TEST").getProtoNode().getCmp());
+        assertEquals("ex", FilterNodeBuilder.exists("price").getProtoNode().getCmp());
+        assertEquals("nex", FilterNodeBuilder.notExists("internal_id").getProtoNode().getCmp());
+        assertEquals("sw", FilterNodeBuilder.startsWith("ticker", "AA").getProtoNode().getCmp());
+        assertEquals("ew", FilterNodeBuilder.endsWith("source", "DAQ").getProtoNode().getCmp());
+        assertEquals("ct", FilterNodeBuilder.contains("category", "ec").getProtoNode().getCmp());
+        assertEquals("gt", FilterNodeBuilder.gt("price", "100").getProtoNode().getCmp());
+        assertEquals("gte", FilterNodeBuilder.gte("volume", "1000").getProtoNode().getCmp());
+        assertEquals("lt", FilterNodeBuilder.lt("price", "200").getProtoNode().getCmp());
+        assertEquals("lte", FilterNodeBuilder.lte("volume", "1000").getProtoNode().getCmp());
+    }
+
+    @Test
+    public void testBuilderSetMembership() {
+        Protocol.FilterNode in = FilterNodeBuilder.in("category", "tech", "finance").getProtoNode();
+        assertEquals("in", in.getCmp());
+        assertEquals(2, in.getValsCount());
+        assertEquals("tech", in.getVals(0));
+
+        Protocol.FilterNode nin = FilterNodeBuilder.nin("ticker", "MSFT", "GOOGL").getProtoNode();
+        assertEquals("nin", nin.getCmp());
+        assertEquals(2, nin.getValsCount());
+    }
+
+    @Test
+    public void testBuilderLogicalNodes() {
+        Protocol.FilterNode and = FilterNodeBuilder.and(
+                FilterNodeBuilder.eq("ticker", "AAPL"),
+                FilterNodeBuilder.gte("price", "100"),
+                FilterNodeBuilder.in("source", "NASDAQ", "NYSE")).getProtoNode();
+        assertEquals("and", and.getOp());
+        assertEquals(3, and.getNodesCount());
+        assertEquals("ticker", and.getNodes(0).getKey());
+        assertEquals("in", and.getNodes(2).getCmp());
+
+        Protocol.FilterNode or = FilterNodeBuilder.or(
+                FilterNodeBuilder.eq("ticker", "MSFT"),
+                FilterNodeBuilder.eq("category", "tech")).getProtoNode();
+        assertEquals("or", or.getOp());
+        assertEquals(2, or.getNodesCount());
+
+        Protocol.FilterNode not = FilterNodeBuilder.not(FilterNodeBuilder.eq("source", "NYSE")).getProtoNode();
+        assertEquals("not", not.getOp());
+        assertEquals(1, not.getNodesCount());
+        assertEquals("eq", not.getNodes(0).getCmp());
+    }
+
+    @Test
+    public void testSetTagsFilterRejectsDeltaCombination() throws Exception {
+        Client client = new Client(server.url(), new Options(), new EventListener() {});
+        SubscriptionOptions opts = new SubscriptionOptions();
+        opts.setDelta("fossil");
+        Subscription sub = client.newSubscription("market:stocks", opts, new SubscriptionEventListener() {});
+        try {
+            sub.setTagsFilter(FilterNodeBuilder.eq("ticker", "AAPL"));
+            fail("expected IllegalStateException");
+        } catch (IllegalStateException expected) {
+            // ok
+        }
+        client.close(1000);
+    }
+
+    @Test
+    public void testSubscribeRequestCarriesTagsFilter() throws Exception {
+        SubscriptionOptions opts = new SubscriptionOptions();
+        opts.setTagsFilter(FilterNodeBuilder.and(
+                FilterNodeBuilder.eq("ticker", "AAPL"),
+                FilterNodeBuilder.gte("price", "100")));
+
+        LinkedBlockingQueue<SubscribedEvent> subscribedQ = new LinkedBlockingQueue<>();
+        CountDownLatch connected = new CountDownLatch(1);
+        Client client = new Client(server.url(), new Options(), new EventListener() {
+            @Override public void onConnected(Client c, ConnectedEvent e) { connected.countDown(); }
+        });
+        client.connect();
+        Subscription sub = client.newSubscription("market:stocks", opts, new SubscriptionEventListener() {
+            @Override public void onSubscribed(Subscription s, SubscribedEvent e) { subscribedQ.add(e); }
+        });
+        sub.subscribe();
+        try {
+            assertTrue(connected.await(5, TimeUnit.SECONDS));
+            assertNotNull(subscribedQ.poll(5, TimeUnit.SECONDS));
+
+            Protocol.FilterNode tf = server.lastSubscribe().getTf();
+            assertEquals("and", tf.getOp());
+            assertEquals(2, tf.getNodesCount());
+            assertEquals("ticker", tf.getNodes(0).getKey());
+            assertEquals("eq", tf.getNodes(0).getCmp());
+            assertEquals("AAPL", tf.getNodes(0).getVal());
+            assertEquals("gte", tf.getNodes(1).getCmp());
+        } finally {
+            client.close(1000);
+        }
+    }
+
+    @Test
+    public void testSetTagsFilterAppliesOnSubscribe() throws Exception {
+        LinkedBlockingQueue<SubscribedEvent> subscribedQ = new LinkedBlockingQueue<>();
+        CountDownLatch connected = new CountDownLatch(1);
+        Client client = new Client(server.url(), new Options(), new EventListener() {
+            @Override public void onConnected(Client c, ConnectedEvent e) { connected.countDown(); }
+        });
+        client.connect();
+        Subscription sub = client.newSubscription("market:stocks", new SubscriptionEventListener() {
+            @Override public void onSubscribed(Subscription s, SubscribedEvent e) { subscribedQ.add(e); }
+        });
+        sub.setTagsFilter(FilterNodeBuilder.eq("ticker", "BTC"));
+        sub.subscribe();
+        try {
+            assertTrue(connected.await(5, TimeUnit.SECONDS));
+            assertNotNull(subscribedQ.poll(5, TimeUnit.SECONDS));
+
+            Protocol.FilterNode tf = server.lastSubscribe().getTf();
+            assertEquals("ticker", tf.getKey());
+            assertEquals("BTC", tf.getVal());
+        } finally {
+            client.close(1000);
+        }
+    }
+
+    @Test
+    public void testSubscribeWithoutFilterSendsNoTf() throws Exception {
+        LinkedBlockingQueue<SubscribedEvent> subscribedQ = new LinkedBlockingQueue<>();
+        CountDownLatch connected = new CountDownLatch(1);
+        Client client = new Client(server.url(), new Options(), new EventListener() {
+            @Override public void onConnected(Client c, ConnectedEvent e) { connected.countDown(); }
+        });
+        client.connect();
+        Subscription sub = client.newSubscription("market:stocks", new SubscriptionEventListener() {
+            @Override public void onSubscribed(Subscription s, SubscribedEvent e) { subscribedQ.add(e); }
+        });
+        sub.subscribe();
+        try {
+            assertTrue(connected.await(5, TimeUnit.SECONDS));
+            assertNotNull(subscribedQ.poll(5, TimeUnit.SECONDS));
+            assertFalse(server.lastSubscribe().hasTf());
+        } finally {
+            client.close(1000);
+        }
+    }
+}


### PR DESCRIPTION
Adds support for [publication filtering](https://centrifugal.dev/docs/server/publication_filtering) by publication tags.

A subscription can carry a tags filter so the server delivers only publications whose tags match it — reducing bandwidth and client-side processing.

### API

- `FilterNodeBuilder` helpers: `eq`, `neq`, `in`, `nin`, `exists`, `notExists`, `startsWith`, `endsWith`, `contains`, `gt`, `gte`, `lt`, `lte`, `and`, `or`, `not`.
- `SubscriptionOptions.setTagsFilter(...)` to set at creation.
- `Subscription.setTagsFilter(...)` to set/replace before the next subscribe.
- Mutually exclusive with delta compression (validated).

### Example

```java
SubscriptionOptions opts = new SubscriptionOptions();
opts.setTagsFilter(FilterNodeBuilder.and(
    FilterNodeBuilder.eq("ticker", "AAPL"),
    FilterNodeBuilder.gte("price", "100")));
Subscription sub = client.newSubscription("market:stocks", opts, listener);
```

Tests added in `FilterTest.java`: builder unit tests plus fake-server wire tests asserting the subscribe request carries the `tf` field (and sends none when unset).
