### PR TITLE
Support state invalidation

### DIFF
--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Client.java
@@ -116,6 +116,17 @@ public class Client {
     // impossible (only sent when SUBSCRIPTION_FLAG_REJECT_UNRECOVERED was requested).
     static final int ERROR_CODE_UNRECOVERABLE_POSITION = 112;
 
+    // Server-sent "state invalidated" codes. The server determines that the
+    // client's cached state and/or token are no longer valid and asks the client
+    // to drop them and re-sync.
+    //
+    // 2502 arrives in an Unsubscribe push for a single subscription (the client
+    // clears the subscription state and resubscribes, since it's >= 2500). 3014
+    // arrives for the whole connection (the client clears the connection token to
+    // force a fresh one via getToken, invalidates all subscriptions, reconnects).
+    static final int UNSUBSCRIBED_STATE_INVALIDATED = 2502;
+    static final int DISCONNECTED_STATE_INVALIDATED = 3014;
+
     /**
      * Creates a new instance of Client. Client allows to allocate new Subscriptions to channels,
      * automatically manages reconnects and re-subscriptions on temporary failures.
@@ -230,6 +241,18 @@ public class Client {
     void processDisconnect(int code, String reason, Boolean shouldReconnect) {
         if (this.getState() == ClientState.DISCONNECTED || this.getState() == ClientState.CLOSED) {
             return;
+        }
+
+        if (code == DISCONNECTED_STATE_INVALIDATED) {
+            // State invalidated (delivered as a WebSocket close frame or a Disconnect
+            // push, both funnel here): drop the connection token so the next connect
+            // fetches a fresh one via the token getter, and invalidate every
+            // subscription's cached state before reconnecting.
+            this.token = "";
+            this.refreshRequired = true;
+            for (Subscription sub : this.subs.values()) {
+                sub.invalidateState();
+            }
         }
 
         ClientState previousState = this.getState();
@@ -1067,6 +1090,11 @@ public class Client {
             if (unsubscribe.getCode() < 2500) {
                 sub.moveToUnsubscribed(false, unsubscribe.getCode(), unsubscribe.getReason());
             } else {
+                if (unsubscribe.getCode() == UNSUBSCRIBED_STATE_INVALIDATED) {
+                    // State invalidated: drop the subscription token and cached state so
+                    // the resubscribe below obtains a fresh token and re-syncs.
+                    sub.invalidateState();
+                }
                 sub.moveToSubscribing(unsubscribe.getCode(), unsubscribe.getReason());
                 sub.resubscribeIfNecessary();
             }

--- a/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
+++ b/centrifuge/src/main/java/io/github/centrifugal/centrifuge/Subscription.java
@@ -597,4 +597,23 @@ public class Subscription {
         this.pushId = id;
         this.client.updateSubscriptionPushId(this, oldId, id);
     }
+
+    // Resets cached subscription state on "state invalidated" (unsubscribe code
+    // 2502 or connection disconnect code 3014) so the resubscribe re-syncs: clears
+    // the token (next subscribe fetches a fresh one via the token getter), the
+    // fossil delta base (a stale base would corrupt decoding of the first
+    // publication), and the channel-compaction ID mapping. The recovery position
+    // is reset to a sentinel epoch ("_") the server can never match (offset 0);
+    // the recover flag is left untouched. So a recoverable subscription
+    // resubscribes with wasRecovering=true, recovered=false — letting the app
+    // reload via its existing recovery-failure path — while a non-recoverable one
+    // just resubscribes (the sentinel is not sent). The real epoch/offset are
+    // adopted from the subscribe reply. Runs on the client executor thread.
+    void invalidateState() {
+        this.token = "";
+        this.offset = 0;
+        this.epoch = "_";
+        this.prevData = null;
+        this.setPushId(0);
+    }
 }

--- a/centrifuge/src/test/java/io/github/centrifugal/centrifuge/FakeCentrifugoServer.java
+++ b/centrifuge/src/test/java/io/github/centrifugal/centrifuge/FakeCentrifugoServer.java
@@ -136,6 +136,18 @@ public final class FakeCentrifugoServer {
         }
     }
 
+    /**
+     * Close the active connection from the server side with a specific code,
+     * the way Centrifugo delivers a server disconnect (e.g. 3014 state
+     * invalidated) — as a WebSocket close frame rather than a Disconnect push.
+     */
+    public void disconnect(int code, String reason) {
+        WebSocket s = currentSocket.get();
+        if (s != null) {
+            s.close(code, reason);
+        }
+    }
+
     private final class ServerListener extends WebSocketListener {
         @Override
         public void onOpen(WebSocket webSocket, Response response) {

--- a/centrifuge/src/test/java/io/github/centrifugal/centrifuge/StateInvalidationTest.java
+++ b/centrifuge/src/test/java/io/github/centrifugal/centrifuge/StateInvalidationTest.java
@@ -1,0 +1,172 @@
+package io.github.centrifugal.centrifuge;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.github.centrifugal.centrifuge.internal.protocol.Protocol;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for "state invalidated" handling: unsubscribe code 2502 (per-subscription)
+ * and disconnect code 3014 (connection-wide). On these the client drops cached
+ * tokens (and recovery position / delta base) so a fresh token is obtained and
+ * the subscription re-syncs. Private fields aren't visible to tests, so behavior
+ * is asserted over the wire against the in-process {@link FakeCentrifugoServer}.
+ */
+public class StateInvalidationTest {
+
+    private FakeCentrifugoServer server;
+
+    @Before
+    public void setUp() throws IOException {
+        server = new FakeCentrifugoServer();
+        server.start();
+    }
+
+    @After
+    public void tearDown() {
+        server.stop();
+    }
+
+    private Protocol.SubscribeRequest lastSubscribe() {
+        return server.lastSubscribe();
+    }
+
+    private Protocol.ConnectRequest lastConnect() {
+        Protocol.ConnectRequest last = null;
+        for (Protocol.Command cmd : server.received()) {
+            if (cmd.hasConnect()) {
+                last = cmd.getConnect();
+            }
+        }
+        return last;
+    }
+
+    @Test
+    public void testUnsubscribe2502ClearsSubTokenAndResubscribes() throws Exception {
+        LinkedBlockingQueue<SubscribedEvent> subscribedQ = new LinkedBlockingQueue<>();
+        CountDownLatch connected = new CountDownLatch(1);
+        Options opts = new Options();
+        opts.setMinReconnectDelay(50);
+        Client client = new Client(server.url(), opts, new EventListener() {
+            @Override public void onConnected(Client c, ConnectedEvent e) { connected.countDown(); }
+        });
+        client.connect();
+
+        SubscriptionOptions subOpts = new SubscriptionOptions();
+        subOpts.setToken("sub-token-0");
+        Subscription sub = client.newSubscription("ch", subOpts, new SubscriptionEventListener() {
+            @Override public void onSubscribed(Subscription s, SubscribedEvent e) { subscribedQ.add(e); }
+        });
+        sub.subscribe();
+        try {
+            assertTrue(connected.await(5, TimeUnit.SECONDS));
+            assertNotNull("subscribed", subscribedQ.poll(5, TimeUnit.SECONDS));
+            assertEquals("initial subscribe carries the token", "sub-token-0", lastSubscribe().getToken());
+
+            // Server sends "state invalidated" unsubscribe — the subscription must
+            // drop its token and resubscribe with an empty token (no token getter
+            // configured, so nothing repopulates it).
+            server.unsubscribePush("ch", Client.UNSUBSCRIBED_STATE_INVALIDATED, "state invalidated");
+            assertNotNull("resubscribed after 2502", subscribedQ.poll(5, TimeUnit.SECONDS));
+            assertEquals("token cleared by 2502", "", lastSubscribe().getToken());
+        } finally {
+            client.close(1000);
+        }
+    }
+
+    @Test
+    public void testUnsubscribe2502RecoverableResubscribesUnrecovered() throws Exception {
+        // A recoverable subscription must resubscribe REQUESTING recovery (recover
+        // flag left true) but from the sentinel epoch "_" the server can't match,
+        // so it gets wasRecovering=true, recovered=false.
+        server.onSubscribe = (channel, req) -> Protocol.SubscribeResult.newBuilder()
+                .setRecoverable(true).setEpoch("server-epoch").setOffset(5).build();
+
+        LinkedBlockingQueue<SubscribedEvent> subscribedQ = new LinkedBlockingQueue<>();
+        CountDownLatch connected = new CountDownLatch(1);
+        Client client = new Client(server.url(), new Options(), new EventListener() {
+            @Override public void onConnected(Client c, ConnectedEvent e) { connected.countDown(); }
+        });
+        client.connect();
+        Subscription sub = client.newSubscription("ch", new SubscriptionEventListener() {
+            @Override public void onSubscribed(Subscription s, SubscribedEvent e) { subscribedQ.add(e); }
+        });
+        sub.subscribe();
+        try {
+            assertTrue(connected.await(5, TimeUnit.SECONDS));
+            assertNotNull("subscribed", subscribedQ.poll(5, TimeUnit.SECONDS));
+            assertFalse("initial subscribe does not request recovery", lastSubscribe().getRecover());
+
+            server.unsubscribePush("ch", Client.UNSUBSCRIBED_STATE_INVALIDATED, "state invalidated");
+            assertNotNull("resubscribed after 2502", subscribedQ.poll(5, TimeUnit.SECONDS));
+
+            Protocol.SubscribeRequest req = lastSubscribe();
+            assertTrue("resubscribe requests recovery (recover left true)", req.getRecover());
+            assertEquals("resubscribe carries the unrecoverable sentinel epoch", "_", req.getEpoch());
+            assertEquals("resubscribe offset reset to 0", 0L, req.getOffset());
+        } finally {
+            client.close(1000);
+        }
+    }
+
+    @Test
+    public void testDisconnect3014ClearsConnTokenRefreshesAndInvalidatesSubs() throws Exception {
+        LinkedBlockingQueue<ConnectedEvent> connectedQ = new LinkedBlockingQueue<>();
+        LinkedBlockingQueue<SubscribedEvent> subscribedQ = new LinkedBlockingQueue<>();
+        AtomicInteger connTokenCalls = new AtomicInteger();
+
+        Options opts = new Options();
+        opts.setToken("conn-token-0");
+        opts.setMinReconnectDelay(50);
+        opts.setMaxReconnectDelay(200);
+        opts.setTokenGetter(new ConnectionTokenGetter() {
+            @Override
+            public void getConnectionToken(ConnectionTokenEvent e, TokenCallback cb) {
+                connTokenCalls.incrementAndGet();
+                cb.Done(null, "conn-token-1");
+            }
+        });
+        Client client = new Client(server.url(), opts, new EventListener() {
+            @Override public void onConnected(Client c, ConnectedEvent e) { connectedQ.add(e); }
+        });
+        client.connect();
+
+        SubscriptionOptions subOpts = new SubscriptionOptions();
+        subOpts.setToken("sub-token-0");
+        Subscription sub = client.newSubscription("ch", subOpts, new SubscriptionEventListener() {
+            @Override public void onSubscribed(Subscription s, SubscribedEvent e) { subscribedQ.add(e); }
+        });
+        sub.subscribe();
+        try {
+            assertNotNull("connected", connectedQ.poll(5, TimeUnit.SECONDS));
+            assertNotNull("subscribed", subscribedQ.poll(5, TimeUnit.SECONDS));
+            assertEquals("initial connect uses provided token", "conn-token-0", lastConnect().getToken());
+
+            // Server sends "state invalidated" disconnect — the client must clear
+            // its connection token, fetch a fresh one via the token getter on
+            // reconnect, and invalidate the subscription (resubscribe w/o token).
+            server.disconnect(Client.DISCONNECTED_STATE_INVALIDATED, "state invalidated");
+
+            assertNotNull("reconnected after 3014", connectedQ.poll(5, TimeUnit.SECONDS));
+            assertTrue("connection token getter called after 3014", connTokenCalls.get() >= 1);
+            assertEquals("reconnect uses freshly fetched token", "conn-token-1", lastConnect().getToken());
+
+            assertNotNull("resubscribed after 3014", subscribedQ.poll(5, TimeUnit.SECONDS));
+            assertEquals("sub token cleared by 3014", "", lastSubscribe().getToken());
+        } finally {
+            client.close(1000);
+        }
+    }
+}


### PR DESCRIPTION
Handles server "state invalidated" signals so clients drop stale cached state and re-sync:

- **Unsubscribe code 2502** (per-subscription): clears the subscription token and cached state, then resubscribes.
- **Disconnect code 3014** (connection-wide): clears the connection token (forcing a fresh one via the token getter), invalidates every subscription, and reconnects. Funneled through `processDisconnect`, so it fires from **both** the Disconnect push and the WebSocket close frame.

`invalidateState` clears the token, fossil delta base and channel-compaction id, and resets the recovery position to a sentinel epoch (`"_"`, offset 0) the server can never match — leaving the `recover` flag untouched. So a recoverable subscription resubscribes with `wasRecovering=true, recovered=false` (the app reloads via its existing recovery-failure path), while a non-recoverable one just resubscribes. The real epoch/offset are adopted from the subscribe reply.

Tests in `StateInvalidationTest.java`: 2502 clears sub token + resubscribes, recoverable 2502 resubscribes unrecovered (`recover=true, epoch="_"`), 3014 refreshes the connection token and invalidates subs.
